### PR TITLE
Feature/6 Academy 화면 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1328,6 +1329,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1393,6 +1395,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -1892,6 +1895,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2249,6 +2253,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2826,6 +2831,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3011,6 +3017,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4949,6 +4956,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4958,6 +4966,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4977,6 +4986,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4999,7 +5009,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5679,6 +5690,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5841,6 +5853,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6125,6 +6138,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/academy/academy.module.css
+++ b/src/app/academy/academy.module.css
@@ -1,0 +1,95 @@
+.academyContainer {
+  background-color: var(--white);
+  padding: 2rem 3rem;
+  border-radius: var(--radius-sm);
+
+  width: 100%;
+  min-width: var(--container-width);
+  margin: 0 auto;
+
+  box-sizing: border-box;
+}
+
+/* 공통 섹션 박스 (가로 기준) */
+.sectionBox {
+  padding: 16px;
+  margin-bottom: 20px;
+  box-sizing: border-box;
+}
+
+/* academy 페이지 공통 제목 */
+.academyContainer h2 {
+  text-align: center;
+  color: var(--text-main);
+  margin-bottom: 18px;
+  font-weight: bold;
+}
+
+/* 파일 업로드 박스 */
+.fileBox {
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #fafafa;
+}
+
+.fileGuide {
+  font-size: 13px;
+  color: #666;
+  margin-top: 8px;
+}
+
+/* 안내 박스 */
+.noticeWrapper {
+  padding: 0;
+}
+
+.noticeTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.noticeIcon {
+  flex-shrink: 0;
+}
+
+.noticeTitle {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.noticeSubList {
+  margin-top: 8px;
+  padding-left: 18px;
+  font-size: 13px;
+  color: #9ca3af;
+  line-height: 1.5;
+}
+
+.noticeSubList li {
+  margin-bottom: 4px;
+}
+
+/* 다음 버튼 */
+.nextButton {
+  width: 100%;
+  height: 48px;
+
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+
+  background-color: #2563eb;
+  color: white;
+  border: none;
+
+  cursor: pointer;
+}
+
+.nextButton:disabled {
+  background-color: #e5e7eb;
+  color: #9ca3af;
+  cursor: not-allowed;
+}

--- a/src/app/academy/complete/complete.module.css
+++ b/src/app/academy/complete/complete.module.css
@@ -1,0 +1,60 @@
+/* 전체 컨테이너 */
+.completeContainer {
+  background-color: var(--white);
+  padding: 2rem 3rem;                  /* 좌우 3rem, academyContainer와 동일 */
+  width: 100%;
+  min-width: var(--container-width);   /* academyContainer와 동일 */
+  margin: 0 auto;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+
+  max-height: 100vh;   /* 화면 세로 제한 */
+  overflow-y: auto;    /* 세로 스크롤 허용 */
+}
+
+/* 제목 영역 */
+.titleWrapper {
+  display: flex;
+  justify-content: center; /* 가로 가운데 정렬 */
+  margin-top: 40px;        /* 상단 여백 */
+  margin-bottom: 24px;     /* 아래 여백 */
+}
+
+/* 완료 페이지 주요 텍스트 */
+.completeTitle {
+  font-size: 16px;        /* h3보다는 조금 작게 */
+  font-weight: 500;       /* 진하지 않게 */
+  color: #111827;         /* 거의 검정 */
+  text-align: center;
+  margin-bottom: 8px;     /* 문단 간 간격 */
+}
+
+/* 안내 문단 */
+.completeText {
+  font-size: 14px;
+  font-weight: 400;       /* 일반 글씨 */
+  color: #6b7280;         /* 연한 회색 */
+  line-height: 1.6;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+/* 섹션 박스 (여백 통일용) */
+.sectionBox {
+  padding: 0;
+  margin-bottom: 16px;
+  box-sizing: border-box;
+}
+
+/* 버튼 */
+.nextButton {
+  width: 100%;
+  height: 48px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  cursor: pointer;
+}

--- a/src/app/academy/complete/page.tsx
+++ b/src/app/academy/complete/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import styles from './complete.module.css';
+import AcademyTitle from "../components/AcademyTitle";
+
+export default function AcademyCompletePage() {
+  const router = useRouter();
+
+  return (
+    <div className={styles.completeContainer}>
+      <div className={styles.titleWrapper}>
+        <AcademyTitle title="학원 등록 완료" />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <p className={styles.completeTitle}>학원 등록이 완료되었습니다.</p>
+        <p className={styles.completeTitle}>
+          관리자 승인까지 1~3일 정도 소요될 수 있습니다.
+        </p>
+        <p className={styles.completeText}>
+          승인 완료 후 출결, 수업 관리, 수납 관리 등 모든 기능을 이용하실 수 있습니다.
+        </p>
+      </div>
+
+      <div className={styles.sectionBox}>
+        <button
+          className={styles.nextButton}
+          onClick={() => router.push("/")}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/academy/components/AcademyTitle.tsx
+++ b/src/app/academy/components/AcademyTitle.tsx
@@ -1,0 +1,3 @@
+export default function AcademyTitle({ title }: { title: string }) {
+  return <h2 >{title}</h2>;
+}

--- a/src/app/academy/components/MultiFileInput.tsx
+++ b/src/app/academy/components/MultiFileInput.tsx
@@ -1,0 +1,76 @@
+type Props = {
+  label: string;
+  files: File[];
+  onChange: (files: File[]) => void;
+};
+
+export default function MultiFileInput({ label, files, onChange }: Props) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    onChange(Array.from(e.target.files));
+  };
+
+  return (
+    <div>
+      <p style={{ fontWeight: 600, marginBottom: "8px" }}>{label}</p>
+
+      {/* 숨겨진 파일 인풋 */}
+      <input
+        id="business-file"
+        type="file"
+        multiple
+        onChange={handleChange}
+        style={{ display: "none" }}
+      />
+
+      {/* 커스텀 버튼 */}
+      <label htmlFor="business-file" style={{ cursor: "pointer" }}>
+        <div
+          style={{
+            border: "1px dashed #ccc",
+            borderRadius: "8px",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          {/* SVG 아이콘 */}
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 14.4238V17.0008C3 18.3815 4.11929 19.5008 5.5 19.5008H18.2692C19.6499 19.5008 20.7692 18.3815 20.7692 17.0008V14.4238"
+              stroke="black"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M6.80762 8.07696L11.8846 3M11.8846 3L16.9615 8.07696M11.8846 3V14.4231"
+              stroke="black"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+
+          <p style={{ marginTop: "8px", fontSize: "14px" }}>
+            파일 선택
+          </p>
+        </div>
+      </label>
+
+      {/* 선택된 파일 목록 */}
+      {files.length > 0 && (
+        <ul style={{ marginTop: "10px", fontSize: "14px" }}>
+          {files.map((file, idx) => (
+            <li key={idx}>{file.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/academy/components/MultiSelect.tsx
+++ b/src/app/academy/components/MultiSelect.tsx
@@ -1,0 +1,54 @@
+// MultiSelect.tsx
+import { useState } from "react";
+import styles from "../form/form.module.css";
+
+type Props = {
+  label: string;
+  options: string[];
+  selected: string[];
+  onChange: (value: string[]) => void;
+};
+
+export default function MultiSelect({ label, options, selected, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const toggleOption = (value: string) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <div className={styles.multiSelectWrapper}>
+      <label className={styles.multiSelectLabel}>{label}</label>
+
+      {/* 선택 박스 */}
+      <div
+        className={styles.multiSelectBox}
+        onClick={() => setOpen(!open)}
+      >
+        {selected.length > 0 ? selected.join(", ") : "선택"}
+        <span className={styles.arrow}>{open ? "▲" : "▼"}</span>
+      </div>
+
+      {/* 옵션 리스트 */}
+      {open && (
+        <div className={styles.multiSelectOptionsDropdown}>
+          {options.map((opt) => (
+            <div
+              key={opt}
+              className={`${styles.multiSelectOption} ${
+                selected.includes(opt) ? styles.selected : ""
+              }`}
+              onClick={() => toggleOption(opt)}
+            >
+              {opt}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/academy/components/NoticeBox.tsx
+++ b/src/app/academy/components/NoticeBox.tsx
@@ -1,0 +1,14 @@
+export default function NoticeBox({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        background: "#f5f5f5",
+        padding: "12px",
+        fontSize: "14px",
+        marginBottom: "16px",
+      }}
+    >
+       {text}
+    </div>
+  );
+}

--- a/src/app/academy/components/TextInput.tsx
+++ b/src/app/academy/components/TextInput.tsx
@@ -1,0 +1,20 @@
+import styles from "../form/form.module.css";
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export default function TextInput({ label, value, onChange }: Props) {
+  return (
+    <div className={styles.textInputWrapper}>
+      <label className={styles.textInputLabel}>{label}</label>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={styles.textInputField}
+      />
+    </div>
+  );
+}

--- a/src/app/academy/form/form.module.css
+++ b/src/app/academy/form/form.module.css
@@ -1,15 +1,21 @@
 .formContainer {
   background-color: var(--white);
-  padding: 2rem 3rem;           /* academyContainer와 동일 */
+  padding: 2rem 3rem;
   width: 100%;
-  min-width: var(--container-width); /* academyContainer와 동일 */
+  min-width: var(--container-width);
   margin: 0 auto;
   border-radius: var(--radius-sm);
   box-sizing: border-box;
 
-  max-height: 100vh;     /* 세로 스크롤 유지 */
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+
+  gap: 24px; /* ⭐ 모든 폼 요소 간 간격 통일 */
+
+
+  overflow-y: visible;
 }
+
 
 
 .titleWrapper {
@@ -21,7 +27,7 @@
 
 .sectionBox {
   padding: 0;           /* 섹션 내부 패딩 제거 */
-  margin-bottom: 16px;  /* 섹션 간 간격 통일 */
+  margin-top: 16px;  /* 섹션 간 간격 통일 */
   box-sizing: border-box;
 }
 
@@ -29,14 +35,14 @@
 .textInputWrapper {
   display: flex;
   flex-direction: column;
-  margin-bottom: 0; /* sectionBox가 간격 담당 */
+ 
 }
 
 .textInputLabel {
   font-weight: 500;
   font-size: 14px;
   color: #6b7280;
-  margin-bottom: 4px; /* input과 간격 */
+  margin-bottom: 6px; /* input과 간격 */
 }
 
 .textInputField {
@@ -49,38 +55,48 @@
   outline: none;
 }
 
-/* MultiSelect 스타일 */
-.multiSelectBox {
-  border: 1px solid #dcdcdc;
-  padding: 8px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  position: relative;
-  background-color: #fff;
-  
+
+
+/* ===== MultiSelect ===== */
+.multiSelectWrapper {
+  position: relative; /* ⭐ 핵심 */
+  display: flex;
+  flex-direction: column;
 }
 
 .multiSelectLabel {
   font-weight: 500;
   font-size: 14px;
-  color: #6b7280; /* 연한 회색 */
-  margin-bottom: 4px;
+  color: #6b7280;
+  margin-bottom: 6px;
 }
 
+.multiSelectBox {
+  border: 1px solid #dcdcdc;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  background-color: #fff;
+}
 
 .arrow {
   float: right;
 }
 
 .multiSelectOptionsDropdown {
+  position: absolute;      /* ⭐ 핵심 */
+  top: calc(100% + 4px);   /* 🔥 핵심 */
+  left: 0;
+  width: 100%;
+
   border: 1px solid #dcdcdc;
   border-radius: 8px;
   margin-top: 4px;
   max-height: 150px;
   overflow-y: auto;
   background-color: #fff;
-  z-index: 10;
-  position: relative;
+
+  z-index: 9999;           /* ⭐ 핵심 */
 }
 
 .multiSelectOption {
@@ -92,10 +108,21 @@
   background-color: #f0f0f0;
 }
 
-.multiSelectOption.selected {
+.selected {
   background-color: #2563eb;
   color: white;
 }
+
+
+
+
+
+
+
+
+
+
+
 
 
 /* 등록 버튼 */

--- a/src/app/academy/form/form.module.css
+++ b/src/app/academy/form/form.module.css
@@ -1,0 +1,112 @@
+.formContainer {
+  background-color: var(--white);
+  padding: 2rem 3rem;           /* academyContainer와 동일 */
+  width: 100%;
+  min-width: var(--container-width); /* academyContainer와 동일 */
+  margin: 0 auto;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+
+  max-height: 100vh;     /* 세로 스크롤 유지 */
+  overflow-y: auto;
+}
+
+
+.titleWrapper {
+  display: flex;
+  justify-content: center; /* 가로 가운데 정렬 */
+  margin-top: 40px;        /* 상단 여백 */
+  margin-bottom: 24px;     /* 아래 여백 */
+}
+
+.sectionBox {
+  padding: 0;           /* 섹션 내부 패딩 제거 */
+  margin-bottom: 16px;  /* 섹션 간 간격 통일 */
+  box-sizing: border-box;
+}
+
+/* TextInput 스타일 */
+.textInputWrapper {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0; /* sectionBox가 간격 담당 */
+}
+
+.textInputLabel {
+  font-weight: 500;
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 4px; /* input과 간격 */
+}
+
+.textInputField {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 14px;
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  box-sizing: border-box;
+  outline: none;
+}
+
+/* MultiSelect 스타일 */
+.multiSelectBox {
+  border: 1px solid #dcdcdc;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  position: relative;
+  background-color: #fff;
+  
+}
+
+.multiSelectLabel {
+  font-weight: 500;
+  font-size: 14px;
+  color: #6b7280; /* 연한 회색 */
+  margin-bottom: 4px;
+}
+
+
+.arrow {
+  float: right;
+}
+
+.multiSelectOptionsDropdown {
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  margin-top: 4px;
+  max-height: 150px;
+  overflow-y: auto;
+  background-color: #fff;
+  z-index: 10;
+  position: relative;
+}
+
+.multiSelectOption {
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.multiSelectOption:hover {
+  background-color: #f0f0f0;
+}
+
+.multiSelectOption.selected {
+  background-color: #2563eb;
+  color: white;
+}
+
+
+/* 등록 버튼 */
+.nextButton {
+  width: 100%;
+  height: 48px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  cursor: pointer;
+}

--- a/src/app/academy/form/page.tsx
+++ b/src/app/academy/form/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import AcademyTitle from "../components/AcademyTitle";
+import TextInput from "../components/TextInput";
+import MultiSelect from "../components/MultiSelect";
+import styles from "./form.module.css";
+
+export default function AcademyFormPage() {
+  const router = useRouter();
+
+  // 상태값 분리
+  const [address, setAddress]=useState("");
+  const [phone, setPhone] = useState("");
+  const [ages, setAges] = useState<string[]>([]);
+  const [subjects, setSubjects] = useState<string[]>([]);
+  const [intro, setIntro] = useState("");
+  const [operatingHours, setOperatingHours] = useState("");
+  const [tuition, setTuition] = useState("");
+  const [levelTest, setLevelTest] = useState("");
+  const [website, setWebsite] = useState("");
+  const [instagram, setInstagram] = useState("");
+  const [blog, setBlog] = useState("");
+
+  
+  return (
+    <div className={styles.formContainer}>
+      <div className={styles.titleWrapper}>
+        <AcademyTitle title="학원 정보 입력" />
+      </div>
+
+    <div className={styles.sectionBox}>
+        <TextInput label="주소" value={address} onChange={setAddress} />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput label="전화번호" value={phone} onChange={setPhone} />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <MultiSelect
+          label="학원생 나이"
+          options={["초등학생", "중학생", "고등학생", "성인"]}
+          selected={ages}
+          onChange={setAges}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <MultiSelect
+          label="과목"
+          options={["수학", "영어", "국어", "과학", "코딩"]}
+          selected={subjects}
+          onChange={setSubjects}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput label="학원 소개글(선택)" value={intro} onChange={setIntro} />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput
+          label="운영 시간(선택)"
+          value={operatingHours}
+          onChange={setOperatingHours}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput
+          label="수업 비용(선택)"
+          value={tuition}
+          onChange={setTuition}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput
+          label="레벨 테스트(선택)"
+          value={levelTest}
+          onChange={setLevelTest}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput label="홈페이지" value={website} onChange={setWebsite} />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput
+          label="인스타그램"
+          value={instagram}
+          onChange={setInstagram}
+        />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <TextInput label="네이버 블로그" value={blog} onChange={setBlog} />
+      </div>
+
+      <div className={styles.sectionBox}>
+        <button
+          className={styles.nextButton}
+          onClick={() => router.push("/academy/complete")}
+        >
+          등록하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/academy/form/page.tsx
+++ b/src/app/academy/form/page.tsx
@@ -6,12 +6,20 @@ import AcademyTitle from "../components/AcademyTitle";
 import TextInput from "../components/TextInput";
 import MultiSelect from "../components/MultiSelect";
 import styles from "./form.module.css";
+import { useSubjects } from "@/hooks/useSubjects";
+import { useAges } from "@/hooks/useAges";
+import { createAcademy } from "@/api/academyApi";
+import { useAcademy } from "@/context/AcademyContext";
 
 export default function AcademyFormPage() {
   const router = useRouter();
+  const { academyName, businessFiles } = useAcademy();
 
-  // 상태값 분리
-  const [address, setAddress]=useState("");
+  const { subjectOptions, loading: subjectLoading } = useSubjects();
+  const { ageOptions, loading: ageLoading } = useAges();
+
+  const [baseAddress, setBaseAddress] = useState("");
+  const [detailAddress, setDetailAddress] = useState("");
   const [phone, setPhone] = useState("");
   const [ages, setAges] = useState<string[]>([]);
   const [subjects, setSubjects] = useState<string[]>([]);
@@ -23,87 +31,79 @@ export default function AcademyFormPage() {
   const [instagram, setInstagram] = useState("");
   const [blog, setBlog] = useState("");
 
-  
+  // 선택한 문자열 → id 배열
+  const selectedAgeIds = ages
+    .map(label => ageOptions.find(a => a.label === label)?.value)
+    .filter((v): v is number => v !== undefined);
+
+  const selectedSubjectIds = subjects
+    .map(label => subjectOptions.find(s => s.label === label)?.value)
+    .filter((v): v is number => v !== undefined);
+
+  const handleRegister = async () => {
+    if (!academyName || businessFiles.length === 0) {
+      alert("학원명과 사업자등록증을 먼저 입력해주세요.");
+      return;
+    }
+
+    try {
+      await createAcademy({
+        name: academyName,
+        baseAddress,
+        detailAddress,
+        phoneNumber: phone,
+        briefInfo: intro,
+        websiteUrl: website,
+        instagramUrl: instagram,
+        blogUrl: blog,
+        certificateFile: businessFiles[0],
+        ageIds: selectedAgeIds,
+        subjects: selectedSubjectIds,
+      });
+      router.push("/academy/complete");
+    } catch (err) {
+      console.error(err);
+      alert("학원 등록 중 오류가 발생했습니다.");
+    }
+  };
+
+  if (ageLoading || subjectLoading) return <div>로딩 중...</div>;
+
   return (
     <div className={styles.formContainer}>
-      <div className={styles.titleWrapper}>
-        <AcademyTitle title="학원 정보 입력" />
-      </div>
+      <AcademyTitle title="학원 정보 입력" />
 
-    <div className={styles.sectionBox}>
-        <TextInput label="주소" value={address} onChange={setAddress} />
-      </div>
+      <TextInput label="기본 주소" value={baseAddress} onChange={setBaseAddress} />
+      <TextInput label="상세 주소" value={detailAddress} onChange={setDetailAddress} />
+      <TextInput label="전화번호" value={phone} onChange={setPhone} />
 
-      <div className={styles.sectionBox}>
-        <TextInput label="전화번호" value={phone} onChange={setPhone} />
-      </div>
+      <MultiSelect
+        label="학원생 나이"
+        options={ageOptions.map(a => a.label)}
+        selected={ages}
+        onChange={setAges}
+      />
 
-      <div className={styles.sectionBox}>
-        <MultiSelect
-          label="학원생 나이"
-          options={["초등학생", "중학생", "고등학생", "성인"]}
-          selected={ages}
-          onChange={setAges}
-        />
-      </div>
+      <MultiSelect
+        label="과목"
+        options={subjectOptions.map(s => s.label)}
+        selected={subjects}
+        onChange={setSubjects}
+      />
 
-      <div className={styles.sectionBox}>
-        <MultiSelect
-          label="과목"
-          options={["수학", "영어", "국어", "과학", "코딩"]}
-          selected={subjects}
-          onChange={setSubjects}
-        />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput label="학원 소개글(선택)" value={intro} onChange={setIntro} />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput
-          label="운영 시간(선택)"
-          value={operatingHours}
-          onChange={setOperatingHours}
-        />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput
-          label="수업 비용(선택)"
-          value={tuition}
-          onChange={setTuition}
-        />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput
-          label="레벨 테스트(선택)"
-          value={levelTest}
-          onChange={setLevelTest}
-        />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput label="홈페이지" value={website} onChange={setWebsite} />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput
-          label="인스타그램"
-          value={instagram}
-          onChange={setInstagram}
-        />
-      </div>
-
-      <div className={styles.sectionBox}>
-        <TextInput label="네이버 블로그" value={blog} onChange={setBlog} />
-      </div>
+      <TextInput label="학원 소개글(선택)" value={intro} onChange={setIntro} />
+      <TextInput label="운영 시간(선택)" value={operatingHours} onChange={setOperatingHours} />
+      <TextInput label="수업 비용(선택)" value={tuition} onChange={setTuition} />
+      <TextInput label="레벨 테스트(선택)" value={levelTest} onChange={setLevelTest} />
+      <TextInput label="홈페이지" value={website} onChange={setWebsite} />
+      <TextInput label="인스타그램" value={instagram} onChange={setInstagram} />
+      <TextInput label="네이버 블로그" value={blog} onChange={setBlog} />
 
       <div className={styles.sectionBox}>
         <button
           className={styles.nextButton}
-          onClick={() => router.push("/academy/complete")}
+          onClick={handleRegister}
+          disabled={!academyName || businessFiles.length === 0}
         >
           등록하기
         </button>

--- a/src/app/academy/page.tsx
+++ b/src/app/academy/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import AcademyTitle from "./components/AcademyTitle";
+import TextInput from "./components/TextInput";
+import MultiFileInput from "./components/MultiFileInput";
+import styles from "./academy.module.css";
+
+export default function AcademyStartPage() {
+  const router = useRouter();
+  const [academyName, setAcademyName] = useState("");
+  const [businessFiles, setBusinessFiles] = useState<File[]>([]);
+
+  return (
+    <div className={styles.academyContainer}>
+      <AcademyTitle title="학원 등록하기" />
+
+      <div className={styles.sectionBox}>
+       <TextInput
+         label="학원명"  
+         value={academyName}
+         onChange={setAcademyName}
+        />
+      </div>
+
+
+      {/* 파일 업로드 영역 */}
+      <div className={styles.sectionBox}>
+        <div className={styles.fileBox}>
+          <MultiFileInput
+            label="사업자 등록증 제출"
+            files={businessFiles}
+            onChange={setBusinessFiles}
+          />
+          <p className={styles.fileGuide}>
+            사진 또는 캡처화면 제출 (png, jpg, pdf)
+          </p>
+        </div>
+      </div>
+
+      {/* 안내 영역 */}
+      <div className={styles.sectionBox}>
+        <div className={styles.noticeWrapper}>
+          <div className={styles.noticeTitleRow}>
+            <svg
+              className={styles.noticeIcon}
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 3
+                   C7.029 3 3 7.029 3 12
+                   C3 16.971 7.029 21 12 21
+                   C16.971 21 21 16.971 21 12
+                   C21 7.029 16.971 3 12 3Z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                fill="none"
+              />
+              <line
+                x1="12"
+                y1="7"
+                x2="12"
+                y2="14"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              <circle cx="12" cy="17" r="1" fill="currentColor" />
+            </svg>
+
+            <p className={styles.noticeTitle}>
+              학원 관계자 확인을 위해 사업자등록증을 업로드해 주세요
+            </p>
+          </div>
+
+          <ul className={styles.noticeSubList}>
+            <li>제출된 사업자등록증은 학원 인증 용도로만 사용됩니다.</li>
+            <li>인증 완료 전까지 일부 기능 이용이 제한될 수 있습니다.</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* 다음 버튼 */}
+      <div className={styles.sectionBox}>
+        <button
+          className={styles.nextButton}
+          disabled={!academyName || businessFiles.length === 0}
+          onClick={() => router.push("/academy/form")}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAges.ts
+++ b/src/hooks/useAges.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getAges, Age } from "@/api/ageApi";
+
+export const useAges = () => {
+  const [ages, setAges] = useState<Age[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchAges = async () => {
+      try {
+        const data = await getAges();
+        setAges(data);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAges();
+  }, []);
+
+  /** 🔥 UI에서 바로 쓰는 값 */
+  const ageOptions = ages.map((age) => age.ageCode);
+
+  return { ageOptions, loading, error };
+};

--- a/src/hooks/useSubjects.ts
+++ b/src/hooks/useSubjects.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { getSubjects, Subject } from "@/api/subjectApi";
+
+export const useSubjects = () => {
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchSubjects = async () => {
+      try {
+        const data = await getSubjects();
+        setSubjects(data);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSubjects();
+  }, []);
+
+  return { subjects, loading, error };
+};


### PR DESCRIPTION
## Academy 화면 구현 (학원 등록 플로우)

Academy 관련 화면을 구현했습니다.  
이번 작업으로 다음 3개의 페이지가 추가되었습니다.

1. 학원 등록하기
2. 학원 정보 입력
3. 학원 등록 완료

---

### 데이터 조회 / 저장 구조 관련

학원 정보 입력 페이지에서  
**학원생 나이 / 과목 정보는 백엔드 API를 통해 조회**하고 있습니다.

- 현재
  - 나이: 영어 값으로 저장
  - 과목: 한글 값으로 저장
- 백엔드 쪽에서 데이터 포맷 통일이 필요해 보입니다.

또한 구조적으로,

- **조회(Read)**  
  - 화면 상태 관리가 필요해 `hook + api` 구조 사용  
  - (ex. `useSubjects`, `subjectApi`)
- **저장(Create/Update)**  
  - 버튼 클릭 시 트리거성 동작이어서 `academyApi`만 사용

이라는 기준으로 구현했는데,  
이 구조를 **조회/저장 모두 동일한 패턴으로 통일하는 것이 좋을지**  
리뷰 의견 부탁드립니다.

---

### 레이아웃 구성

- academy 페이지 전반에 `(auth)` 전역 레이아웃을 재사용했습니다.
- layout.tsx를 분리해 UI 일관성을 맞췄습니다.

해당 구조에 대한 피드백도 함께 부탁드립니다 🙇‍♀️

---

Closes #5
