### PR TITLE
fix/7 학원 승인 대기 시 사이드바 비활성화 및 헤더 UX 개선

### DIFF
--- a/src/app/academy/(with-sidebar)/[academyId]/Dashboard.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/Dashboard.module.css
@@ -1,8 +1,6 @@
 .pageLayout {
   display: flex;
   width: 100%;
-  height: 100vh;
-  overflow: hidden;
 }
 
 .mainContent {
@@ -14,7 +12,6 @@
   display: flex;
   flex-direction: column;
   padding: 24px;
-  overflow-y: auto;
 }
 
 .promoBanner > p,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,0 @@
-export default function Main() {
-  return <div>첫 페이지!</div>;
-}

--- a/src/components/auth/AuthSection.tsx
+++ b/src/components/auth/AuthSection.tsx
@@ -54,6 +54,7 @@ export default function AuthSection() {
 
       <button type="button">알림</button>
       <button type="button">프로필</button>
+      <Link href="/academy/register">학원 등록</Link>
       <button type="button" onClick={handleLogout}>
         로그아웃
       </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+
 import styles from "./Header.module.css";
 import AuthSection from "../auth/AuthSection";
 import { LogoIcon } from "../icons/LogoIcon";
@@ -13,9 +13,9 @@ export default function Header() {
 
   return (
     <nav className={styles.header}>
-      <Link href="/" className={styles.headerLogo} aria-label="쿠카티처스 홈">
+      <div className={styles.headerLogo} aria-label="쿠카티처스 로고">
         <LogoIcon />
-      </Link>
+      </div>
       <div className={styles.headerLinks}>
         {!isAuthPage && <AuthSection />}
       </div>

--- a/src/components/layout/Sidebar.module.css
+++ b/src/components/layout/Sidebar.module.css
@@ -13,6 +13,12 @@
   overflow-y: auto;
 }
 
+.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+  filter: grayscale(100%);
+}
+
 .menuList,
 .subList {
   list-style: none;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { usePathname, useParams } from 'next/navigation';
 import Link from 'next/link';
 import style from './Sidebar.module.css';
+import { dashboardService } from '@/services/dashboardService';
 
 interface SidebarProps {
   academyId: string;
@@ -18,6 +19,20 @@ export default function Sidebar({ academyId: propsId }: SidebarProps) {
   const [isManagementOpen, setIsManagementOpen] = useState(
     pathname.includes('/attendance') || pathname.includes('/payment')
   );
+  const [approvalStatus, setApprovalStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      if (!academyId) return;
+      try {
+        const data = await dashboardService.getAcademyInfo(academyId);
+        setApprovalStatus(data.approvalStatus);
+      } catch (error) {
+        console.error('Failed to fetch academy status:', error);
+      }
+    };
+    fetchStatus();
+  }, [academyId]);
 
   const getMenuClass = (path: string) => {
     const fullPath = `/academy/${academyId}${path === '/' ? '' : path}`;
@@ -31,7 +46,7 @@ export default function Sidebar({ academyId: propsId }: SidebarProps) {
   };
 
   return (
-    <nav className={style.sidebar}>
+    <nav className={`${style.sidebar} ${approvalStatus === 'PENDING' ? style.disabled : ''}`}>
       <ul className={style.menuList}>
         <div className={style.menuGroupTitle}>학원</div>
         <li className={style.menuItem}>


### PR DESCRIPTION
## 🔍 변경 사항

**1. 승인 대기 학원 사이드바 비활성화**
- [Sidebar.tsx](cci:7://file:///d:/qoocca-fe/src/components/layout/Sidebar.tsx:0:0-0:0): 현재 접속한 학원의 상태가 `PENDING`(승인 대기)일 경우, 사이드바 메뉴 전체를 비활성화(클릭 방지, 흐릿하게 처리)하여 사용자가 기능 접근이 불가능함을 직관적으로 알 수 있도록 수정했습니다.
- [Sidebar.module.css](cci:7://file:///d:/qoocca-fe/src/components/layout/Sidebar.module.css:0:0-0:0): 비활성화 스타일(`.disabled`) 추가.

**2. 헤더 UX 개선**
- [AuthSection.tsx](cci:7://file:///d:/qoocca-fe/src/components/auth/AuthSection.tsx:0:0-0:0): 로그인한 원장님이 언제든 새 학원을 등록할 수 있도록 헤더에 **'학원 등록'** 버튼을 추가했습니다. (알림 - 학원 등록 - 프로필 순서)
- [Header.tsx](cci:7://file:///d:/qoocca-fe/src/components/layout/Header.tsx:0:0-0:0): 로고 클릭 시 홈으로 이동하던 기능을 제거했습니다. (현재 페이지 유지)

## 📸 스크린샷 (Optional)
<img width="1918" height="944" alt="image" src="https://github.com/user-attachments/assets/9dfb6ce9-77c0-4e8c-949e-fdc8518df4c2" />

## 📢 기타
- 대시보드 진입 시 승인 대기 상태임이 모달로 안내되므로, 사이드바는 아예 동작하지 않도록 처리하는 것이 더 명확한 UX라고 판단했습니다.