### PR TITLE
feature/15 학원 전환 기능 추가 및 UX/인증 플로우 대규모 리팩토링

### DIFF
--- a/src/api/academyApi.ts
+++ b/src/api/academyApi.ts
@@ -40,3 +40,14 @@ export const createAcademy = async (payload: AcademyCreatePayload) => {
   });
   return response.data; // 등록된 학원 ID 반환
 };
+
+export interface AcademyListResponse {
+  academyId: number;
+  name: string;
+  approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
+}
+
+export const getMyAcademyList = async () => {
+  const response = await axios.get<AcademyListResponse[]>("/api/academy/academy-list");
+  return response.data;
+};

--- a/src/app/(auth)/social-auth/page.tsx
+++ b/src/app/(auth)/social-auth/page.tsx
@@ -68,12 +68,17 @@ export default function SocialAuthPage() {
             },
       });
 
-      const { accessToken } = res.data;
+      const { accessToken, academyId } = res.data;
       Cookies.set('accessToken', accessToken, { expires: 1, path: '/' });
       dispatch(setUserFromToken(accessToken));
 
       toast.success(isExistingUser ? '계정 연결 성공!' : '회원가입 성공!');
-      router.replace('/');
+      
+      if (academyId) {
+        router.replace(`/academy/${academyId}`);
+      } else {
+        router.replace('/academy/register');
+      }
     } catch (err: any) {
       toast.error(err.response?.data?.message || '처리에 실패했습니다.');
     } finally {

--- a/src/app/academy/(with-sidebar)/[academyId]/components/AttendanceRightSidebar.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/components/AttendanceRightSidebar.tsx
@@ -36,7 +36,6 @@ export default function AttendanceRightSidebar({ academyId, classTitle }: Props)
           `/api/attendance/academy/${academyId}/today`
         );
         
-        console.log("전체 출결 데이터:", response.data);
         setAttendances(response.data);
       } catch (error) {
         console.error('전체 출석 현황 로딩 실패:', error);

--- a/src/app/academy/register/complete/page.tsx
+++ b/src/app/academy/register/complete/page.tsx
@@ -1,12 +1,22 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import styles from './complete.module.css';
 import AcademyTitle from '../components/AcademyTitle';
 import Button from '../../../../components/common/Button';
 
 export default function AcademyCompletePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const academyId = searchParams.get('academyId');
+
+  const handleConfirm = () => {
+    if (academyId) {
+      router.push(`/academy/${academyId}`);
+    } else {
+      router.push('/');
+    }
+  };
 
   return (
     <div className={styles.completeContainer}>
@@ -28,7 +38,7 @@ export default function AcademyCompletePage() {
       </div>
 
       <div className={styles.sectionBox}>
-        <Button onClick={() => router.push('/')}>확인</Button>
+        <Button onClick={handleConfirm}>확인</Button>
       </div>
     </div>
   );

--- a/src/app/academy/register/form/page.tsx
+++ b/src/app/academy/register/form/page.tsx
@@ -48,7 +48,7 @@ export default function AcademyFormPage() {
     }
 
     try {
-      await createAcademy({
+      const academyId = await createAcademy({
         name: academyName,
         baseAddress,
         detailAddress,
@@ -61,7 +61,7 @@ export default function AcademyFormPage() {
         ageIds: selectedAgeIds,
         subjects: selectedSubjectIds,
       });
-      router.push('/academy/complete');
+      router.push(`/academy/register/complete?academyId=${academyId}`);
     } catch (err) {
       console.error(err);
       alert('학원 등록 중 오류가 발생했습니다.');

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,7 +50,7 @@ body {
 }
 
 .layoutWrapper:has(nav) .mainContent {
-  margin-left: 212px;
+  margin-left: 240px;
 }
 
 .mainContent {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,16 +9,22 @@ import { usePathname } from "next/navigation";
 
 export default function Header() {
   const pathname = usePathname();
-  const isAuthPage = pathname === "/login" || pathname === "/signup";
+  const isAuthPage = 
+    pathname === "/login" || 
+    pathname === "/signup" || 
+    pathname === "/social-auth" ||
+    pathname?.startsWith("/oauth2");
 
   return (
     <nav className={styles.header}>
       <div className={styles.headerLogo} aria-label="쿠카티처스 로고">
         <LogoIcon />
       </div>
-      <div className={styles.headerLinks}>
-        {!isAuthPage && <AuthSection />}
-      </div>
+      {!isAuthPage && (
+        <div className={styles.headerLinks}>
+          <AuthSection />
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/layout/Sidebar.module.css
+++ b/src/components/layout/Sidebar.module.css
@@ -1,8 +1,8 @@
 .sidebar {
-  width: 212px;
+  width: 240px;
   background-color: #ffffff;
   border-right: 1px solid var(--divider-color);
-  padding: 20px;
+  padding: 80px 20px 20px 20px;
   box-sizing: border-box;
   position: fixed;
   top: 0;
@@ -122,4 +122,33 @@
   color: #adb5bd;
   margin: 16px 0 8px 16px;
   text-transform: uppercase;
+}
+
+.academySwitcher {
+  padding: 0 0 20px 0;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 20px;
+}
+
+.academySelect {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background-color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s;
+}
+
+.academySelect:hover {
+  border-color: #d1d5db;
+}
+
+.academySelect:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname, useParams } from 'next/navigation';
 import Link from 'next/link';
 import style from './Sidebar.module.css';
 import { dashboardService } from '@/services/dashboardService';
+import { getMyAcademyList, AcademyListResponse } from '@/api/academyApi';
 
 interface SidebarProps {
   academyId: string;
@@ -29,6 +30,7 @@ export default function Sidebar({ academyId: propsId }: SidebarProps) {
         setApprovalStatus(data.approvalStatus);
       } catch (error) {
         console.error('Failed to fetch academy status:', error);
+        setApprovalStatus('PENDING');
       }
     };
     fetchStatus();
@@ -45,9 +47,50 @@ export default function Sidebar({ academyId: propsId }: SidebarProps) {
     return `${style.subLinkItem} ${isActive ? style.active : ''}`;
   };
 
+  const [academies, setAcademies] = useState<AcademyListResponse[]>([]);
+
+  useEffect(() => {
+    const fetchAcademies = async () => {
+      try {
+        const data = await getMyAcademyList();
+        setAcademies(data);
+      } catch (error) {
+        console.error('Failed to fetch academy list:', error);
+      }
+    };
+    fetchAcademies();
+  }, []);
+
+  const getStatusLabel = (status: string) => {
+    switch (status) {
+      case 'APPROVED': return '';
+      case 'PENDING': return '(승인 대기)';
+      case 'REJECTED': return '(승인 거절)';
+      default: return '';
+    }
+  };
+
+  const handleAcademyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newAcademyId = e.target.value;
+    window.location.href = `/academy/${newAcademyId}`;
+  };
+
   return (
-    <nav className={`${style.sidebar} ${approvalStatus === 'PENDING' ? style.disabled : ''}`}>
-      <ul className={style.menuList}>
+    <nav className={style.sidebar}>
+      <div className={style.academySwitcher}>
+        <select 
+          value={academyId} 
+          onChange={handleAcademyChange}
+          className={style.academySelect}
+        >
+          {academies.map((academy) => (
+            <option key={academy.academyId} value={academy.academyId}>
+              {academy.name} {getStatusLabel(academy.approvalStatus)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <ul className={`${style.menuList} ${approvalStatus === 'PENDING' ? style.disabled : ''}`}>
         <div className={style.menuGroupTitle}>학원</div>
         <li className={style.menuItem}>
           <Link href={`/academy/${academyId}`} className={getMenuClass('/')}>


### PR DESCRIPTION
1. 사이드바 (Sidebar) & 학원 전환
- Academy Switcher: 사이드바 상단에 드롭다운 메뉴를 추가하여 보유한 학원 간 빠른 전환이 가능하도록 구현
- Real Data Integration: /api/academy/academy-list API를 연동하여 실제 사용자의 학원 목록을 조회
- Status Display: 학원 이름 옆에 승인 상태를 표시 (단, '운영 중' 상태일 때는 라벨을 숨겨 깔끔하게 처리하고, '승인 대기/거절'일 때만 표시)
- Layout Fix: 고정 헤더(60px)에 사이드바 상단이 가려지는 문제를 해결하기 위해 padding-top을 80px로 조정
- Smart Disabled State: 학원 승인 대기(PENDING) 시 사이드바 메뉴(ul)는 비활성화하지만, 상단 학원 전환 드롭다운은 활성화 상태를 유지하여 다른 학원으로 이동 가능하도록 개선

2. 헤더 (Header)
- Auth Page Optimization: /login, /signup, /social-auth 등 인증 관련 페이지에서는 헤더 우측 버튼 컨테이너를 비노출 처리하여 빈 테두리가 보이는 UI 버그 수정

3. 학원 등록 프로세스 (Registration Flow)
- Registration Redirect: createAcademy 성공 후 생성된 academyId를 완료 페이지로 전달
- Completion Action: 완료 페이지에서 '확인' 버튼 클릭 시, 홈이 아닌 해당 학원의 대시보드로 즉시 이동하도록 흐름 개선

**관련 파일 (Affected Files)**
src/components/layout/Sidebar.tsx, Sidebar.module.css
src/api/academyApi.ts (API 추가 및 수정)
src/components/layout/Header.tsx
src/app/academy/register/form/page.tsx
src/app/academy/register/complete/page.tsx
src/app/globals.css

Closes #32 