### PR TITLE
feature/16 add modal Academy

### DIFF
--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import Loading from '@/components/common/Loading';
+import { AcademyInfo } from '@/types/dashboard';
 
 export default function LoginForm() {
   const dispatch = useDispatch();
@@ -27,19 +28,15 @@ export default function LoginForm() {
     try {
       const data = await authService.login({
         email,
-        password
+        password,
       });
 
-      const { accessToken, academyId } = data;
+      const { accessToken, academyId, academies } = data;
 
       if (accessToken) {
         dispatch(setUserFromToken(accessToken));
-      }
-
-      if (academyId) {
-        router.push(`/academy/${academyId}`);
-      } else {
-        router.push('/academy/register');
+        toast.success('로그인 성공!');
+        router.push('/academy');
       }
     } catch (err: any) {
       const errorMessage =
@@ -49,6 +46,7 @@ export default function LoginForm() {
       setIsLoading(false);
     }
   };
+
 
   return (
     <form onSubmit={handleLogin} className={styles.form}>
@@ -85,6 +83,7 @@ export default function LoginForm() {
           '로그인'
         )}
       </Button>
-    </form>
+
+    </form >
   );
 }

--- a/src/app/(auth)/oauth2/redirect/SocialHandler.tsx
+++ b/src/app/(auth)/oauth2/redirect/SocialHandler.tsx
@@ -7,6 +7,8 @@ import { setUserFromToken } from '@/store/userSlice';
 import { toast } from 'sonner';
 import Loading from '@/components/common/Loading';
 import axiosInstance from '@/api/axiosInstance';
+import { AcademyInfo } from '@/types/dashboard';
+import { useState } from 'react';
 
 interface SocialHandlerProps {
   provider: 'kakao' | 'naver';
@@ -17,6 +19,8 @@ export default function SocialHandler({ provider }: SocialHandlerProps) {
   const code = searchParams.get('code');
   const router = useRouter();
   const dispatch = useDispatch();
+
+  const [hasFetchedToken, setHasFetchedToken] = useState(false);
 
   const hasFetched = useRef(false); // useEffect가 두 번 실행되는 것을 방지
 
@@ -29,7 +33,7 @@ export default function SocialHandler({ provider }: SocialHandlerProps) {
       try {
         const res = await axiosInstance.post(`/api/auth/${provider}`, { code });
 
-        const { accessToken, socialId, academyId } = res.data;
+        const { accessToken, socialId, academyId, academies } = res.data;
 
         if (accessToken === 'NEED_PHONE_AUTH') {
           toast.info('추가 휴대폰 인증이 필요합니다.');
@@ -41,11 +45,7 @@ export default function SocialHandler({ provider }: SocialHandlerProps) {
         } else {
           dispatch(setUserFromToken(accessToken));
           toast.success('로그인 성공!');
-          if (academyId) {
-            router.push(`/academy/${academyId}`);
-          } else {
-            router.push('/academy/register');
-          }
+          router.replace('/academy');
         }
       } catch (err: any) {
         toast.error(
@@ -58,5 +58,10 @@ export default function SocialHandler({ provider }: SocialHandlerProps) {
     getToken();
   }, [code, provider, dispatch, router]);
 
-  return <Loading provider={provider} />;
+
+  return (
+    <>
+      <Loading provider={provider} />
+    </>
+  );
 }

--- a/src/app/(auth)/signup/components/SignupForm.tsx
+++ b/src/app/(auth)/signup/components/SignupForm.tsx
@@ -20,59 +20,61 @@ export default function SignupForm() {
   } = useSignup();
 
   return (
-    <form onSubmit={handleSignup} className={styles.form}>
-      <Input
-        type="text"
-        placeholder="이름"
-        value={fields.username}
-        onChange={(e) => handleFieldChange('username', e.target.value)}
-        error={errors.username}
-        disabled={auth.isLoading}
-        required
-      />
-      <Input
-        type="email"
-        placeholder="이메일"
-        value={fields.email}
-        onChange={(e) => handleFieldChange('email', e.target.value)}
-        error={errors.email}
-        disabled={auth.isLoading}
-        required
-      />
-      <Input
-        type="password"
-        placeholder="비밀번호"
-        value={fields.password}
-        onChange={(e) => handleFieldChange('password', e.target.value)}
-        error={errors.password}
-        disabled={auth.isLoading}
-        required
-      />
-
-      <PhoneSection
-        phone={fields.phone}
-        setPhone={setFields.setPhone}
-        code={fields.code}
-        setCode={setFields.setCode}
-        isPhoneVerified={auth.isPhoneVerified}
-        setIsPhoneVerified={auth.setIsPhoneVerified}
-        setIsExistingUser={auth.setIsExistingUser}
-      />
-
-      {auth.isPhoneVerified && !auth.isExistingUser && (
-        <TermsSection
-          agreements={agreements.agreements}
-          setAgreements={agreements.setAgreements}
+    <>
+      <form onSubmit={handleSignup} className={styles.form}>
+        <Input
+          type="text"
+          placeholder="이름"
+          value={fields.username}
+          onChange={(e) => handleFieldChange('username', e.target.value)}
+          error={errors.username}
+          disabled={auth.isLoading}
+          required
         />
-      )}
+        <Input
+          type="email"
+          placeholder="이메일"
+          value={fields.email}
+          onChange={(e) => handleFieldChange('email', e.target.value)}
+          error={errors.email}
+          disabled={auth.isLoading}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="비밀번호"
+          value={fields.password}
+          onChange={(e) => handleFieldChange('password', e.target.value)}
+          error={errors.password}
+          disabled={auth.isLoading}
+          required
+        />
 
-      <Button variant="secondary" type="submit" disabled={isSubmitDisabled}>
-        {auth.isLoading
-          ? '처리 중...'
-          : auth.isExistingUser
-          ? '계정 연동'
-          : '가입하기'}
-      </Button>
-    </form>
+        <PhoneSection
+          phone={fields.phone}
+          setPhone={setFields.setPhone}
+          code={fields.code}
+          setCode={setFields.setCode}
+          isPhoneVerified={auth.isPhoneVerified}
+          setIsPhoneVerified={auth.setIsPhoneVerified}
+          setIsExistingUser={auth.setIsExistingUser}
+        />
+
+        {auth.isPhoneVerified && !auth.isExistingUser && (
+          <TermsSection
+            agreements={agreements.agreements}
+            setAgreements={agreements.setAgreements}
+          />
+        )}
+
+        <Button variant="secondary" type="submit" disabled={isSubmitDisabled}>
+          {auth.isLoading
+            ? '처리 중...'
+            : auth.isExistingUser
+              ? '계정 연동'
+              : '가입하기'}
+        </Button>
+      </form>
+    </>
   );
 }

--- a/src/app/academy/(with-sidebar)/[academyId]/Dashboard.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/Dashboard.tsx
@@ -12,11 +12,13 @@ import CustomModal from '@/components/common/CustomModal';
 import AttendanceRightSidebar from './components/AttendanceRightSidebar';
 
 import { dashboardService } from '@/services/dashboardService';
-import { 
-  DashboardStatsData, 
-  ReceiptSummary, 
-  ClassSummary 
+import {
+  DashboardStatsData,
+  ReceiptSummary,
+  ClassSummary,
+  AcademyInfo
 } from '@/types/dashboard';
+import AcademySelectionModal from '@/components/auth/AcademySelectionModal';
 
 interface Props {
   academyId?: string;
@@ -53,10 +55,29 @@ export default function Dashboard({ academyId }: Props) {
   const [selectedClassId, setSelectedClassId] = useState<number | null>(null);
   const selectedClassName = classes.find((c: ClassSummary) => c.classId === selectedClassId)?.className;
 
-  
+  // 학원 선택 모달 관련 상태
+  const [userAcademies, setUserAcademies] = useState<AcademyInfo[]>([]);
+  const [isSelectionModalOpen, setIsSelectionModalOpen] = useState(false);
+
+
   useEffect(() => {
     const fetchData = async () => {
       if (!isRegistered) {
+        // 등록된 학원이 없는 경우 (또는 /academy 경로로 온 경우) 사용자의 학원 목록을 확인
+        try {
+          const academies = await dashboardService.getMyAcademies();
+          setUserAcademies(academies);
+
+          if (academies.length === 1) {
+            // 학원이 1개만 있으면 바로 해당 학원으로 이동
+            router.replace(`/academy/${academies[0].id}`);
+          } else if (academies.length > 1) {
+            // 학원이 여러 개면 모달 오픈
+            setIsSelectionModalOpen(true);
+          }
+        } catch (error) {
+          console.error('학원 목록 조회 실패:', error);
+        }
         setIsLoading(false);
         return;
       }
@@ -82,8 +103,8 @@ export default function Dashboard({ academyId }: Props) {
 
           try {
             const receiptData = await dashboardService.getReceiptSummary(
-              academyId, 
-              new Date().getFullYear(), 
+              academyId,
+              new Date().getFullYear(),
               new Date().getMonth() + 1
             );
             setReceipts(receiptData || []);
@@ -104,21 +125,21 @@ export default function Dashboard({ academyId }: Props) {
   }, [academyId, isRegistered]);
 
   const searchParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
-  
+
   useEffect(() => {
     if (searchParams?.get('alert') === 'access_denied') {
-        // Handle null/error status by defaulting to 'PENDING' or generic message
-        const status = approvalStatus || 'PENDING'; 
-        const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
-        const desc = status === 'PENDING' ? '학원 승인이 완료된 후에 사용할 수 있는 기능입니다.\n조금만 기다려 주세요!' : '등록 정보를 다시 확인해 주세요.';
-        
-        setModalConfig({
-            title: title,
-            description: desc
-        });
-        setIsModalOpen(true);
-        
-        router.replace(`/academy/${academyId}`)
+      // Handle null/error status by defaulting to 'PENDING' or generic message
+      const status = approvalStatus || 'PENDING';
+      const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
+      const desc = status === 'PENDING' ? '학원 승인이 완료된 후에 사용할 수 있는 기능입니다.\n조금만 기다려 주세요!' : '등록 정보를 다시 확인해 주세요.';
+
+      setModalConfig({
+        title: title,
+        description: desc
+      });
+      setIsModalOpen(true);
+
+      router.replace(`/academy/${academyId}`)
     }
   }, [searchParams, approvalStatus, router, academyId]);
 
@@ -134,11 +155,11 @@ export default function Dashboard({ academyId }: Props) {
     }
 
     if (approvalStatus !== 'APPROVED') {
-       // Catch all non-approved states (including null/error)
-       const status = approvalStatus || 'PENDING';
-       const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
-       const desc = status === 'PENDING' 
-        ? '학원 승인이 완료된 후에 사용할 수 있는 기능입니다.\n조금만 기다려 주세요!' 
+      // Catch all non-approved states (including null/error)
+      const status = approvalStatus || 'PENDING';
+      const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
+      const desc = status === 'PENDING'
+        ? '학원 승인이 완료된 후에 사용할 수 있는 기능입니다.\n조금만 기다려 주세요!'
         : '등록 정보를 다시 확인해 주세요.';
 
       setModalConfig({
@@ -156,118 +177,126 @@ export default function Dashboard({ academyId }: Props) {
     <div className={styles.pageLayout}>
       <div className={styles.mainContent}>
 
-      {!isRegistered && (
-        <DashboardBanner isRegistered={isRegistered} approvalStatus={''} />
-      )}
+        {!isRegistered && (
+          <DashboardBanner isRegistered={isRegistered} approvalStatus={''} />
+        )}
 
-      {/* Wrap main interactive area to catch clicks on non-button elements if needed, 
+        {/* Wrap main interactive area to catch clicks on non-button elements if needed, 
           but handleFeatureClick on specific elements is better UX. 
           However, user asked to "show modal when clicking ANYTHING". 
           Let's wrap the interactive parts with a capture handler if not approved. */}
-      <div onClickCapture={(e) => {
+        <div onClickCapture={(e) => {
           if (approvalStatus !== 'APPROVED') {
-              // Prevent default action and stop propagation to prevent navigation
-              e.preventDefault();
-              e.stopPropagation();
-              handleFeatureClick(); 
+            // Prevent default action and stop propagation to prevent navigation
+            e.preventDefault();
+            e.stopPropagation();
+            handleFeatureClick();
           }
-      }}>
-        <DashboardStats
-          isRegistered={isRegistered}
-          studentCount={isRegistered ? stats.studentCount : 0}
-          presentCount={stats.presentCount}
-          totalTodayCount={stats.totalTodayCount}
-          noCardCount={stats.noCardCount}
-          totalMonthlyFee={stats.totalMonthlyFee}
-        />
+        }}>
+          <DashboardStats
+            isRegistered={isRegistered}
+            studentCount={isRegistered ? stats.studentCount : 0}
+            presentCount={stats.presentCount}
+            totalTodayCount={stats.totalTodayCount}
+            noCardCount={stats.noCardCount}
+            totalMonthlyFee={stats.totalMonthlyFee}
+          />
 
-      <h3 className={styles.sectionTitle}>수업 목록</h3>
-      <div className={styles.scrollSection} ref={scrollRef}>
-        <section className={styles.classSection}>
-          {isRegistered &&
-            classes.map((cls: any, index: number) => (
+          <h3 className={styles.sectionTitle}>수업 목록</h3>
+          <div className={styles.scrollSection} ref={scrollRef}>
+            <section className={styles.classSection}>
+              {isRegistered &&
+                classes.map((cls: any, index: number) => (
+                  <ClassCard
+                    key={cls.classId}
+                    name={cls.className}
+                    count={`${cls.presentCount + cls.lateCount}/${cls.currentCount
+                      }`}
+                    late={cls.lateCount}
+                    absent={cls.absentCount}
+                    bgColor={
+                      index % 2 === 0 ? 'var(--tertiary-color)' : 'var(--perple)'
+                    }
+                    onClick={() =>
+                      handleFeatureClick(
+                        `/academy/${academyId}/class/${cls.classId}`
+                      )
+                    }
+                  />
+                ))}
               <ClassCard
-                key={cls.classId}
-                name={cls.className}
-                count={`${cls.presentCount + cls.lateCount}/${
-                  cls.currentCount
-                }`}
-                late={cls.lateCount}
-                absent={cls.absentCount}
-                bgColor={
-                  index % 2 === 0 ? 'var(--tertiary-color)' : 'var(--perple)'
-                }
+                isEmpty
                 onClick={() =>
-                  handleFeatureClick(
-                    `/academy/${academyId}/class/${cls.classId}`
-                  )
+                  handleFeatureClick(`/academy/${academyId}/class/register`)
                 }
               />
-            ))}
-          <ClassCard
-            isEmpty
-            onClick={() =>
-              handleFeatureClick(`/academy/${academyId}/class/register`)
-            }
-          />
-        </section>
-      </div>
+            </section>
+          </div>
 
-      <section
-        className={styles.reportContainer}
-        onClick={() => handleFeatureClick()}
-      >
-        <DashboardReport
-          title="오늘의 보상"
-          headers={['클래스', '수업 시간', '미지급', '지급완료']}
-          isRegistered={isRegistered} 
-          onClick={() => handleFeatureClick(`/academy/${academyId}/reward`)}
+          <section
+            className={styles.reportContainer}
+            onClick={() => handleFeatureClick()}
+          >
+            <DashboardReport
+              title="오늘의 보상"
+              headers={['클래스', '수업 시간', '미지급', '지급완료']}
+              isRegistered={isRegistered}
+              onClick={() => handleFeatureClick(`/academy/${academyId}/reward`)}
+            />
+            <DashboardReport
+              title="이번 달 수납"
+              headers={['클래스', '수업 시간', '수납 상태', '월 수납 금액']}
+              isRegistered={isRegistered}
+              onClick={() => handleFeatureClick(`/academy/${academyId}/payment`)}
+            >
+              {receipts.length > 0 &&
+                receipts.map((item, index) => (
+                  <div key={index} className={styles.reportRowContent}>
+                    <div className={styles.reportItem}>{item.className}</div>
+                    <div className={styles.reportItem}>{item.classTime}</div>
+                    <div
+                      className={`${styles.reportItem} ${styles[`status${item.status}`]
+                        }`}
+                    >
+                      ● {item.statusLabel}
+                    </div>
+                    <div className={`${styles.reportItem} ${styles.amountText}`}>
+                      {item.totalAmount.toLocaleString()}원
+                    </div>
+                  </div>
+                ))}
+            </DashboardReport>
+          </section>
+
+        </div>
+
+        <AcademySelectionModal
+          isOpen={isSelectionModalOpen}
+          onClose={() => setIsSelectionModalOpen(false)}
+          academies={userAcademies}
+          onSelect={(id) => {
+            setIsSelectionModalOpen(false);
+            router.push(`/academy/${id}`);
+          }}
         />
-        <DashboardReport
-          title="이번 달 수납"
-          headers={['클래스', '수업 시간', '수납 상태', '월 수납 금액']}
-          isRegistered={isRegistered}
-          onClick={() => handleFeatureClick(`/academy/${academyId}/payment`)}
-        >
-          {receipts.length > 0 &&
-            receipts.map((item, index) => (
-              <div key={index} className={styles.reportRowContent}>
-                <div className={styles.reportItem}>{item.className}</div>
-                <div className={styles.reportItem}>{item.classTime}</div>
-                <div
-                  className={`${styles.reportItem} ${
-                    styles[`status${item.status}`]
-                  }`}
-                >
-                  ● {item.statusLabel}
-                </div>
-                <div className={`${styles.reportItem} ${styles.amountText}`}>
-                  {item.totalAmount.toLocaleString()}원
-                </div>
-              </div>
-            ))}
-        </DashboardReport>
-      </section>
 
-      </div>
-      
-      <CustomModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        title={modalConfig.title}
-        description={modalConfig.description}
-        actionText={isRegistered ? '확인' : '학원등록'}
-        onAction={() => {
-          setIsModalOpen(false);
-          if (!isRegistered) {
-            router.push('/academy/register');
-          }
-        }}
-      />
+        <CustomModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          title={modalConfig.title}
+          description={modalConfig.description}
+          actionText={isRegistered ? '확인' : '학원등록'}
+          onAction={() => {
+            setIsModalOpen(false);
+            if (!isRegistered) {
+              router.push('/academy/register');
+            }
+          }}
+        />
       </div>
       {isRegistered && approvalStatus === 'APPROVED' && (
-        <AttendanceRightSidebar 
-          academyId={Number(academyId)} 
+        <AttendanceRightSidebar
+          academyId={Number(academyId)}
           classTitle={selectedClassName}
         />
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,4 @@
+// src/app/page.tsx
+export default function Home() {
+    return <div>Hello</div>;
+}

--- a/src/components/auth/AcademySelectionModal.module.css
+++ b/src/components/auth/AcademySelectionModal.module.css
@@ -1,0 +1,104 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.modalContent {
+    background-color: white;
+    padding: 32px;
+    border-radius: 16px;
+    width: 400px;
+    max-width: 90%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.title {
+    font-size: 20px;
+    font-weight: bold;
+    text-align: center;
+    margin: 0;
+    color: #333;
+}
+
+.description {
+    font-size: 14px;
+    color: #666;
+    text-align: center;
+    line-height: 1.5;
+    margin-bottom: 8px;
+}
+
+.academyList {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 300px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.academyItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    border: 1px solid #eee;
+    border-radius: 12px;
+    background-color: #fff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: left;
+}
+
+.academyItem:hover {
+    border-color: var(--primary-color);
+    background-color: #f9f9ff;
+    transform: translateY(-2px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.academyName {
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+}
+
+.academyStatus {
+    font-size: 12px;
+}
+
+.statusApproved {
+    color: #4caf50;
+    font-weight: 500;
+}
+
+.statusPending {
+    color: #ff9800;
+    font-weight: 500;
+}
+
+.statusRejected {
+    color: #f44336;
+    font-weight: 500;
+}
+
+.footer {
+    margin-top: 8px;
+    display: flex;
+    justify-content: center;
+}
+
+.closeButton {
+    width: 100%;
+}

--- a/src/components/auth/AcademySelectionModal.tsx
+++ b/src/components/auth/AcademySelectionModal.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { AcademyInfo } from '@/types/dashboard';
+import styles from './AcademySelectionModal.module.css';
+import Button from '../common/Button';
+
+interface AcademySelectionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    academies: AcademyInfo[];
+    onSelect: (academyId: number) => void;
+}
+
+export default function AcademySelectionModal({
+    isOpen,
+    onClose,
+    academies,
+    onSelect,
+}: AcademySelectionModalProps) {
+    if (!isOpen) return null;
+
+    return (
+        <div className={styles.overlay} onClick={onClose}>
+            <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+                <h3 className={styles.title}>학원을 선택해주세요</h3>
+                <p className={styles.description}>
+                    계정에 등록된 학원이 여러 개 있습니다. <br />
+                    이동하실 학원을 선택해주세요.
+                </p>
+
+                <div className={styles.academyList}>
+                    {academies.map((academy) => (
+                        <button
+                            key={academy.id}
+                            className={styles.academyItem}
+                            onClick={() => onSelect(academy.id)}
+                        >
+                            <div className={styles.academyName}>{academy.name}</div>
+                            <div className={styles.academyStatus}>
+                                {academy.approvalStatus === 'APPROVED' ? (
+                                    <span className={styles.statusApproved}>승인됨</span>
+                                ) : academy.approvalStatus === 'PENDING' ? (
+                                    <span className={styles.statusPending}>대기중</span>
+                                ) : (
+                                    <span className={styles.statusRejected}>거절됨</span>
+                                )}
+                            </div>
+                        </button>
+                    ))}
+                </div>
+
+                <div className={styles.footer}>
+                    <Button variant="gray" onClick={onClose} className={styles.closeButton}>
+                        닫기
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -9,6 +9,7 @@ import {
   validateName,
 } from '../utils/validation';
 import { toast } from 'sonner';
+import { AcademyInfo } from '@/types/dashboard';
 
 export function useSignup() {
   const dispatch = useDispatch();
@@ -24,6 +25,7 @@ export function useSignup() {
   const [isExistingUser, setIsExistingUser] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [agreements, setAgreements] = useState({
+    // ... (skipping some unchanged state lines if possible, but replace_file_content needs exact match)
     service: false,
     privacy: false,
     thirdParty: false,
@@ -77,18 +79,14 @@ export function useSignup() {
 
       dispatch(setUserFromToken(data.accessToken));
       toast.success(isExistingUser ? '계정 연동 성공!' : '회원가입 성공!');
-      
-      if (data.academyId) {
-        router.push(`/academy/${data.academyId}`);
-      } else {
-        router.push('/academy/register');
-      }
+      router.push('/academy');
     } catch (err: any) {
       toast.error('가입 실패: ' + (err.response?.data?.message || '오류 발생'));
     } finally {
       setIsLoading(false);
     }
   };
+
 
   return {
     fields: { username, email, password, phone, code },

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,9 +1,9 @@
 import axiosInstance from '@/api/axiosInstance';
-import { 
-    DashboardStatsData, 
-    ReceiptSummary, 
-    ClassSummary, 
-    AcademyInfo 
+import {
+    DashboardStatsData,
+    ReceiptSummary,
+    ClassSummary,
+    AcademyInfo
 } from '@/types/dashboard';
 
 export const dashboardService = {
@@ -12,6 +12,14 @@ export const dashboardService = {
      */
     getAcademyInfo: async (academyId: string | number): Promise<AcademyInfo> => {
         const response = await axiosInstance.get<AcademyInfo>(`/api/academy/${academyId}`);
+        return response.data;
+    },
+
+    /**
+     * 사용자의 모든 학원 목록 조회
+     */
+    getMyAcademies: async (): Promise<AcademyInfo[]> => {
+        const response = await axiosInstance.get<AcademyInfo[]>('/api/academy');
         return response.data;
     },
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,5 @@
+import { AcademyInfo } from './dashboard';
+
 export interface LoginRequest {
     email: string;
     password: string;
@@ -6,6 +8,7 @@ export interface LoginRequest {
 export interface LoginResponse {
     accessToken: string;
     academyId?: number;
+    academies?: AcademyInfo[];
 }
 
 export interface SignupRequest {
@@ -25,6 +28,7 @@ export interface SignupRequest {
 export interface SignupResponse {
     accessToken: string;
     academyId?: number;
+    academies?: AcademyInfo[];
 }
 
 export interface SendCodeRequest {

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -5,7 +5,7 @@ export interface DashboardStatsData {
     noCardCount: number;
     totalMonthlyFee: number;
 }
-  
+
 export interface ReceiptSummary {
     className: string;
     classTime: string;
@@ -24,7 +24,7 @@ export interface ClassSummary {
 }
 
 export interface AcademyInfo {
-    academyId: number;
+    id: number;
     name: string;
     approvalStatus: 'REJECTED' | 'PENDING' | 'APPROVED';
 }


### PR DESCRIPTION
로그인 및 회원가입 후 발생하는 학원 선택 프로세스를 /academy 랜딩 페이지로 통합하였습니다.

변경 사항 (Changes)
로직 중앙화: 

Dashboard.tsx에서 사용자의 학원 개수를 체크하여:
0개: 학원 등록 배너 표시
1개: 해당 학원 대시보드로 자동 이동 (/academy/{id})
2개 이상: 학원 선택 모달 표시

API 추가: 사용자의 모든 학원 목록을 가져오는 dashboardService.getMyAcademies() 추가 (Endpoint: GET /api/academy)
코드 경량화:
LoginForm, SocialHandler, SignupForm에서 모달 관련 state 및 효과 제거
사용되지 않는 useAuthRedirect.ts 파일 삭제

버그 수정:
소셜 로그인 시 handleRedirect 호출 누락 가능성 제거
회원가입 후 즉시 /academy로 이동하여 선택 절차 진행

리뷰 요청 사항 (Reviewer Notes)
Dashboard.tsx의 useEffect 내에서 학원 목록을 불러오는 타이밍과 리다이렉션 로직이 적절한지 확인 부탁드립니다.
백엔드 GET /api/academy 엔드포인트가 현재 로그인한 유저의 전체 학원 리스트(Deduplicated IDs)를 반환하는지 재확인 부탁드립니다.
useAuthRedirect를 삭제함에 따라 다른 페이지에서 의존성이 없는지  확인했으나, 혹시 놓친 부분이 있는지 봐주시면 감사하겠습니다.😊
