### PR TITLE
feature/17 학원 승인/반려 관리 기능 및 원장님 재심사 요청 프로세스 구현

### DIFF
--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useDispatch } from 'react-redux';
 import { setUserFromToken } from '@/store/userSlice';
+import { jwtDecode } from 'jwt-decode';
 import { authService } from '@/services/authService';
 import styles from './LoginForm.module.css';
 import { toast } from 'sonner';
@@ -36,6 +37,17 @@ export default function LoginForm() {
       if (accessToken) {
         dispatch(setUserFromToken(accessToken));
         toast.success('로그인 성공!');
+
+        // Decode token to check role immediately
+        try {
+          const decoded: any = jwtDecode(accessToken);
+          if (decoded.role === 'ADMIN' || decoded.role === 'ROLE_ADMIN') {
+            router.push('/admin');
+            return;
+          }
+        } catch (e) {
+          console.error('Token decode error:', e);
+        }
 
         // Smart Redirect: 학원이 하나만 있으면 바로 대시보드로 이동
         if (academies && academies.length === 1) {

--- a/src/app/academy/(with-sidebar)/AcademyLayout.module.css
+++ b/src/app/academy/(with-sidebar)/AcademyLayout.module.css
@@ -6,7 +6,7 @@
 
 .mainContent {
   flex: 1;
-  padding: 40px;
+  padding: 40px 40px 10px 40px;
   display: flex;
   flex-direction: column;
 }

--- a/src/app/academy/(with-sidebar)/[academyId]/Dashboard.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/Dashboard.module.css
@@ -113,7 +113,6 @@
   justify-content: space-around;
   width: 100%;
   gap: 40px;
-  margin-bottom: 40px;
 }
 
 .reportRow {
@@ -173,6 +172,11 @@
   color: #999;
 }
 
+.statusNO_STUDENTS {
+  color: #ccc;
+  font-style: italic;
+}
+
 .amountText {
   font-weight: bold;
   color: black;
@@ -227,4 +231,9 @@
 .classSection > div {
   flex-shrink: 0;
   scroll-snap-align: start;
+}
+
+.statusNO_STUDENTS {
+  color: #ccc;
+  font-style: italic;
 }

--- a/src/app/academy/(with-sidebar)/[academyId]/Dashboard.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/Dashboard.tsx
@@ -9,7 +9,8 @@ import DashboardBanner from './components/DashboardBanner';
 import DashboardStats from './components/DashboardStats';
 import DashboardReport from './components/DashboardReport';
 import CustomModal from '@/components/common/CustomModal';
-
+import AcademyRejectionModal from './components/AcademyRejectionModal';
+import { toast } from 'sonner';
 
 import { dashboardService } from '@/services/dashboardService';
 import {
@@ -59,6 +60,22 @@ export default function Dashboard({ academyId }: Props) {
   const [userAcademies, setUserAcademies] = useState<AcademyInfo[]>([]);
   const [isSelectionModalOpen, setIsSelectionModalOpen] = useState(false);
 
+  // 승인 거절 모달 관련 상태
+  const [isRejectionModalOpen, setIsRejectionModalOpen] = useState(false);  // 거절 정보 상태
+  const [rejectionInfo, setRejectionInfo] = useState<{
+    reason: string;
+    academyName: string;
+    files: File[];
+    phoneNumber?: string;
+    baseAddress?: string; // address -> baseAddress 변경
+    detailAddress?: string;
+    submittedFileUrl?: string;
+  }>({
+    reason: '',
+    academyName: '',
+    files: [],
+  });
+
 
   useEffect(() => {
     const fetchData = async () => {
@@ -86,10 +103,23 @@ export default function Dashboard({ academyId }: Props) {
         setIsLoading(true);
 
         const academyInfo = await dashboardService.getAcademyInfo(academyId);
+
+        // --- REAL API DATA USAGE ---
         const status = academyInfo.approvalStatus;
         setApprovalStatus(status);
 
-        if (status === 'APPROVED') {
+        if (status === 'REJECTED') {
+          setRejectionInfo({
+            reason: academyInfo.rejectionReason || '등록 정보에 문제가 있어 승인이 거절되었습니다.\n사유를 확인하고 다시 제출해 주세요.',
+            academyName: academyInfo.name || '',
+            phoneNumber: academyInfo.phoneNumber,
+            baseAddress: academyInfo.baseAddress || '', // baseAddress 연결
+            detailAddress: academyInfo.detailAddress,
+            submittedFileUrl: academyInfo.certificate,
+            files: [],
+          });
+          setIsRejectionModalOpen(true);
+        } else if (status === 'APPROVED') {
           const [classData, statsData] = await Promise.all([
             dashboardService.getClassSummary(academyId),
             dashboardService.getStats(academyId),
@@ -121,12 +151,18 @@ export default function Dashboard({ academyId }: Props) {
     };
 
     fetchData();
-  }, [academyId, isRegistered]);
+  }, [academyId, isRegistered, router]);
 
   const searchParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
 
   useEffect(() => {
     if (searchParams?.get('alert') === 'access_denied') {
+      // 이미 Rejection 모달이 뜨는 경우 중복 방지
+      if (approvalStatus === 'REJECTED') {
+        router.replace(`/academy/${academyId}`);
+        return; 
+      }
+
       const status = approvalStatus || 'PENDING';
       const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
       const desc = status === 'PENDING' ? '학원 승인이 완료된 후에 사용할 수 있는 기능입니다.\n조금만 기다려 주세요!' : '등록 정보를 다시 확인해 주세요.';
@@ -152,6 +188,11 @@ export default function Dashboard({ academyId }: Props) {
     }
 
     if (approvalStatus !== 'APPROVED') {
+      if (approvalStatus === 'REJECTED') {
+        setIsRejectionModalOpen(true);
+        return;
+      }
+      
       const status = approvalStatus || 'PENDING';
       const title = status === 'PENDING' ? '승인 대기 중이에요' : '승인이 거절되었어요';
       const desc = status === 'PENDING'
@@ -167,6 +208,40 @@ export default function Dashboard({ academyId }: Props) {
     }
 
     if (path) router.push(path);
+  };
+
+  const handleRejectionSubmit = async (data: { 
+    academyName: string; 
+    files: File[];
+    // phoneNumber removed
+    baseAddress: string;
+    detailAddress: string;
+  }) => {
+    if (!academyId) return;
+
+    try {
+      const formData = new FormData();
+      formData.append('name', data.academyName);
+      formData.append('baseAddress', data.baseAddress);
+      formData.append('detailAddress', data.detailAddress);
+      
+      // 파일이 새로 업로드된 경우에만 추가
+      if (data.files && data.files.length > 0) {
+        formData.append('certificateFile', data.files[0]);
+      }
+
+      await dashboardService.resubmitAcademy(academyId, formData);
+      
+      toast.success('승인 재요청이 접수되었습니다.');
+      setIsRejectionModalOpen(false);
+      
+      // 상태 갱신: 재요청 후 UI에서 상태를 PENDING으로 즉시 변경
+      setApprovalStatus('PENDING');
+    } catch (error: any) {
+      console.error('승인 재요청 실패:', error);
+      const msg = error.response?.data?.message || '승인 재요청에 실패했습니다.';
+      toast.error(msg);
+    }
   };
 
   return (
@@ -283,6 +358,13 @@ export default function Dashboard({ academyId }: Props) {
               router.push('/academy/register');
             }
           }}
+        />
+
+        <AcademyRejectionModal
+          isOpen={isRejectionModalOpen}
+          onClose={() => setIsRejectionModalOpen(false)}
+          rejectionInfo={rejectionInfo}
+          onSubmit={handleRejectionSubmit}
         />
       </div>
     </div>

--- a/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
@@ -2,6 +2,10 @@
   width: 100%;
   max-width: var(--reg-container-width);
   margin: 0 auto;
+  background-color: var(--white);
+  padding: 2rem 3rem;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }
@@ -10,7 +14,20 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: 18px;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.header h1 {
+  font-size: 32px;
+  color: #111;
+  margin: 0;
 }
 
 .backBtn {

--- a/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
@@ -1,6 +1,6 @@
 .container {
   width: 100%;
-  max-width: var(--container-width);
+  max-width: var(--reg-container-width);
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/class/register/ClassRegisterPage.module.css
@@ -42,68 +42,64 @@
   width: 100%;
 }
 
+
 .label,
 .customLabel {
+  font-weight: 500;
   font-size: 14px;
-  font-weight: 600;
-  color: #333;
+  color: #6b7280;
   margin-bottom: 8px;
   display: block;
 }
 
-.select {
-  width: 100%;
-  height: var(--input-height);
-  border-radius: var(--radius-md);
-  border: 1px solid #eee;
-  padding: 0 16px;
-  font-size: 16px;
-  background-color: white;
-  outline: none;
-  box-sizing: border-box;
-  transition: border-color 0.2s ease;
-}
-
-.select:focus {
-  border-color: #a1ccff;
-  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
-}
-
 .dayContainer {
   display: flex;
-  justify-content: space-around;
-  padding: 12px;
-  background-color: #f8f9fa;
-  border-radius: var(--radius-md);
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .dayItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  flex: 1;
   cursor: pointer;
-  padding: 8px;
-  border-radius: 6px;
-  transition: background-color 0.2s;
+  position: relative;
 }
 
-.dayItem:hover {
-  background-color: #f1f3f5;
+.dayItem input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
 }
 
 .dayItem span {
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background-color: #f3f4f6;
+  color: #6b7280;
+  font-size: 15px;
   font-weight: 500;
-  color: #666;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
 }
 
-.dayItem input[type='checkbox'] {
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
+.dayItem:hover span {
+  background-color: #e5e7eb;
+}
+
+.dayItem input:checked + span {
+  background-color: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .buttonWrapper {
   margin-top: 20px;
 }
+

--- a/src/app/academy/(with-sidebar)/[academyId]/class/register/page.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/class/register/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import styles from './ClassRegisterPage.module.css';
 import Button from '@/components/common/Button';
-import MultiSelect from '@/app/academy/register/components/MultiSelect';
+import Select from '@/components/common/Select';
 
 const DAYS = [
   { id: 'monday', label: '월' },
@@ -30,8 +30,8 @@ export default function ClassRegisterPage() {
     { id: number; detailSubject: string }[]
   >([]);
 
-  const [selectedAge, setSelectedAge] = useState<string[]>([]);
-  const [selectedSubject, setSelectedSubject] = useState<string[]>([]);
+  const [selectedAgeId, setSelectedAgeId] = useState<number | null>(null);
+  const [selectedSubjectId, setSelectedSubjectId] = useState<number | null>(null);
 
   const [formData, setFormData] = useState({
     className: '',
@@ -45,8 +45,6 @@ export default function ClassRegisterPage() {
     saturday: false,
     sunday: false,
     price: '',
-    ageId: '',
-    subjectId: '',
   });
 
   useEffect(() => {
@@ -89,12 +87,7 @@ export default function ClassRegisterPage() {
       return;
     }
 
-    const ageId = ageOptions.find((a) => a.ageCode === selectedAge[0])?.id;
-    const subjectId = subjectOptions.find(
-      (s) => s.detailSubject === selectedSubject[0]
-    )?.id;
-
-    if (!ageId || !subjectId) {
+    if (!selectedAgeId || !selectedSubjectId) {
       toast.error('학년과 과목을 선택해주세요.');
       return;
     }
@@ -102,8 +95,8 @@ export default function ClassRegisterPage() {
     try {
       await axiosInstance.post(`/api/academy/${academyId}/class`, {
         ...formData,
-        ageId,
-        subjectId,
+        ageId: selectedAgeId,
+        subjectId: selectedSubjectId,
       });
       toast.success('클래스가 성공적으로 등록되었습니다.');
       router.push(`/academy/${academyId}`);
@@ -132,20 +125,22 @@ export default function ClassRegisterPage() {
         />
 
         <div className={styles.inputGroup}>
-          <MultiSelect
+          <Select
             label="학년 구분"
-            options={ageOptions.map((a) => a.ageCode)}
-            selected={selectedAge}
-            onChange={(val) => setSelectedAge(val.slice(-1))}
+            options={ageOptions.map((a) => ({ label: a.ageCode, value: a.id }))}
+            value={selectedAgeId}
+            onChange={(val) => setSelectedAgeId(Number(val))}
+            placeholder="학년을 선택하세요"
           />
         </div>
 
         <div className={styles.inputGroup}>
-          <MultiSelect
+          <Select
             label="과목"
-            options={subjectOptions.map((s) => s.detailSubject)}
-            selected={selectedSubject}
-            onChange={(val) => setSelectedSubject(val.slice(-1))}
+            options={subjectOptions.map((s) => ({ label: s.detailSubject, value: s.id }))}
+            value={selectedSubjectId}
+            onChange={(val) => setSelectedSubjectId(Number(val))}
+            placeholder="과목을 선택하세요"
           />
         </div>
 

--- a/src/app/academy/(with-sidebar)/[academyId]/components/AcademyRejectionModal.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/components/AcademyRejectionModal.module.css
@@ -1,0 +1,296 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-in-out;
+}
+
+.modal {
+  background-color: white;
+  padding: 32px;
+  border-radius: 20px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  animation: slideUp 0.3s ease-out;
+}
+
+.header {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 16px;
+  color: #6b7280;
+}
+
+.rejectionAlert {
+  background-color: #fef2f2;
+  border: 1px solid #fee2e2;
+  border-radius: 8px; /* 둥글기 감소 */
+  padding: 12px 16px; /* 패딩 감소 */
+  margin-bottom: 20px; /* 하단 여백 감소 */
+  display: flex;
+  flex-direction: column;
+  gap: 4px; /* 간격 감소 */
+}
+
+.alertTitle {
+  font-size: 13px; /* 폰트 크기 감소 */
+  font-weight: 700;
+  color: #991b1b;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.alertContent {
+  font-size: 14px;
+  color: #b91c1c;
+  line-height: 1.4;
+  margin-left: 2px; /* 시각적 정렬 보정 */
+}
+
+.formSection {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 32px;
+  max-height: 400px; /* 높이 제한 */
+  overflow-y: auto; /* 세로 스크롤 허용 */
+  padding-right: 4px; /* 스크롤바 공간 확보 */
+}
+
+/* Custom Scrollbar for formSection */
+.formSection::-webkit-scrollbar {
+  width: 6px;
+}
+
+.formSection::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.formSection::-webkit-scrollbar-thumb {
+  background-color: #e5e7eb;
+  border-radius: 10px;
+}
+
+.formSection::-webkit-scrollbar-thumb:hover {
+  background-color: #d1d5db;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.previewContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.imageWrapper {
+  position: relative; /* 추가 */
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  background-color: #f9fafb;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.imageWrapper:hover {
+  border-color: var(--primary-color);
+}
+
+.imageHoverOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.imageWrapper:hover .imageHoverOverlay {
+  opacity: 1;
+}
+
+.imageHoverOverlay span {
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 8px 16px;
+  border-radius: 20px;
+}
+
+.previewImage {
+  max-width: 100%;
+  max-height: 240px;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+.viewLinkButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--primary-color);
+  background: none;
+  border: none;
+  padding: 4px 0;
+  cursor: pointer;
+  width: fit-content;
+  transition: opacity 0.2s;
+}
+
+.viewLinkButton:hover {
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
+/* Lightbox Styles */
+.lightboxOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.85);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.lightboxContent {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.fullImage {
+  max-width: 100%;
+  max-height: 90vh;
+  border-radius: 8px;
+  object-fit: contain;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+.closeLightbox {
+  position: absolute;
+  top: -40px;
+  right: -40px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 40px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 10px;
+  transition: transform 0.2s;
+}
+
+.closeLightbox:hover {
+  transform: scale(1.1);
+}
+
+@media (max-width: 768px) {
+  .closeLightbox {
+    right: 0;
+    top: -50px;
+  }
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.cancelButton {
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #4b5563;
+  background-color: #f3f4f6;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.cancelButton:hover {
+  background-color: #e5e7eb;
+}
+
+.submitButton {
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: white;
+  background-color: var(--primary-color);
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.submitButton:hover {
+  background-color: var(--primary-hover);
+}
+
+.submitButton:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}

--- a/src/app/academy/(with-sidebar)/[academyId]/components/AcademyRejectionModal.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/components/AcademyRejectionModal.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import styles from './AcademyRejectionModal.module.css';
+import TextInput from '../../../register/components/TextInput';
+import MultiFileInput from '../../../register/components/MultiFileInput';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  rejectionInfo: {
+    reason: string;
+    academyName: string;
+    files: File[];
+    baseAddress?: string;
+    detailAddress?: string;
+    submittedFileUrl?: string;
+  };
+  onSubmit: (data: { 
+    academyName: string; 
+    files: File[];
+    baseAddress: string;
+    detailAddress: string;
+  }) => void;
+}
+
+export default function AcademyRejectionModal({
+  isOpen,
+  onClose,
+  rejectionInfo,
+  onSubmit,
+}: Props) {
+  const [academyName, setAcademyName] = useState(rejectionInfo.academyName);
+  const [baseAddress, setBaseAddress] = useState(rejectionInfo.baseAddress || '');
+  const [detailAddress, setDetailAddress] = useState(rejectionInfo.detailAddress || '');
+  const [businessFiles, setBusinessFiles] = useState<File[]>(rejectionInfo.files);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      console.log('>>> Modal received submittedFileUrl:', rejectionInfo.submittedFileUrl);
+      setAcademyName(rejectionInfo.academyName);
+      setBaseAddress(rejectionInfo.baseAddress || '');
+      setDetailAddress(rejectionInfo.detailAddress || '');
+      setBusinessFiles(rejectionInfo.files);
+    }
+  }, [isOpen, rejectionInfo]);
+
+  const handleSubmit = () => {
+    onSubmit({ 
+      academyName, 
+      baseAddress,
+      detailAddress,
+      files: businessFiles 
+    });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose}>
+        <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+          <div className={styles.header}>
+            <h2 className={styles.title}>학원 승인이 거절되었어요</h2>
+            <p className={styles.subtitle}>
+              정보를 수정하여 다시 승인 요청을 진행해 주세요.
+            </p>
+          </div>
+
+          <div className={styles.rejectionAlert}>
+            <div className={styles.alertTitle}>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              거절 사유
+            </div>
+            <p className={styles.alertContent}>{rejectionInfo.reason}</p>
+          </div>
+
+          <div className={styles.formSection}>
+            <div className={styles.inputGroup}>
+              <TextInput
+                label="학원명"
+                value={academyName}
+                onChange={setAcademyName}
+                placeholder="학원명을 입력하세요"
+              />
+            </div>
+
+            <div className={styles.inputGroup}>
+              <TextInput
+                label="주소"
+                value={baseAddress}
+                onChange={setBaseAddress}
+                placeholder="도로명 주소 (예: 서울시 강남구...)"
+              />
+            </div>
+
+            <div className={styles.inputGroup}>
+              <TextInput
+                label="상세 주소"
+                value={detailAddress}
+                onChange={setDetailAddress}
+                placeholder="상세 주소 (예: 2층)"
+              />
+            </div>
+
+            {/* 기존 제출 서류 확인 섹션 */}
+            {rejectionInfo.submittedFileUrl && (
+              <div className={styles.inputGroup}>
+                <label className={styles.label}>기존 제출 서류</label>
+                <div className={styles.previewContainer}>
+                  <div 
+                    className={styles.imageWrapper} 
+                    onClick={() => setIsPreviewOpen(true)}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <img
+                      src={rejectionInfo.submittedFileUrl}
+                      alt="기존 사업자등록증"
+                      className={styles.previewImage}
+                      onError={(e) => {
+                        console.error('이미지 로딩 실패:', rejectionInfo.submittedFileUrl);
+                        (e.target as HTMLImageElement).src = 'https://placehold.co/600x400?text=이미지+불러오기+실패';
+                      }}
+                    />
+                    <div className={styles.imageHoverOverlay}>
+                      <span>크게 보기</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className={styles.inputGroup}>
+              <MultiFileInput
+                label="사업자 등록증 제출"
+                files={businessFiles}
+                onChange={setBusinessFiles}
+                description="이미지 또는 PDF 파일"
+              />
+            </div>
+          </div>
+
+          <div className={styles.buttonGroup}>
+            <button className={styles.cancelButton} onClick={onClose}>
+              취소
+            </button>
+            <button
+              className={styles.submitButton}
+              onClick={handleSubmit}
+              disabled={!academyName || !baseAddress || !detailAddress}
+            >
+              승인 재요청
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 이미지 크게 보기 오버레이 */}
+      {isPreviewOpen && rejectionInfo.submittedFileUrl && (
+        <div className={styles.lightboxOverlay} onClick={() => setIsPreviewOpen(false)}>
+          <div className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
+            <button 
+              className={styles.closeLightbox} 
+              onClick={() => setIsPreviewOpen(false)}
+            >
+              &times;
+            </button>
+            <img 
+              src={rejectionInfo.submittedFileUrl} 
+              alt="사업자등록증 원본" 
+              className={styles.fullImage}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/academy/(with-sidebar)/[academyId]/components/AttendanceRightSidebar.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/components/AttendanceRightSidebar.module.css
@@ -2,12 +2,22 @@
   width: 212px;
   background-color: #ffffff;
   border-left: 1px solid #f0f0f0;
-  height: 100%;
-  height: 100%;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow-y: auto;
   padding: 24px;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
+
+  /* Hide scrollbar */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.sidebarContainer::-webkit-scrollbar {
+  display: none;
 }
 
 .headerTitle {
@@ -30,7 +40,6 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  overflow-y: auto;
   margin-bottom: 20px;
 }
 

--- a/src/app/academy/(with-sidebar)/[academyId]/modify/AcademyEditPage.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/modify/AcademyEditPage.module.css
@@ -1,7 +1,11 @@
 .container {
   width: 100%;
-  max-width: var(--container-width);
+  max-width: var(--reg-container-width);
   margin: 0 auto;
+  background-color: var(--white);
+  padding: 2rem 3rem;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }
@@ -10,5 +14,13 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: 18px;
+  gap: 24px;
+}
+
+.form h2 {
+  text-align: center;
+  font-size: 32px;
+  color: #111;
+  margin: 0 0 24px 0;
+  font-weight: bold;
 }

--- a/src/app/academy/(with-sidebar)/[academyId]/payment/PaymentPage.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/payment/PaymentPage.module.css
@@ -277,3 +277,14 @@
 .searchInput::placeholder {
   color: #ccc;
 }
+
+.noCardBadge {
+  font-size: 0.7rem;
+  color: #ff4d4f;
+  background-color: #fff1f0;
+  border: 1px solid #ffccc7;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 8px;
+  white-space: nowrap;
+}

--- a/src/app/academy/(with-sidebar)/[academyId]/payment/components/PaymentRow.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/payment/components/PaymentRow.tsx
@@ -28,12 +28,12 @@ export default function PaymentRow({
 }: Props) {
   const isAllStudentsSelected =
     cls.students &&
-    cls.students.some((s) => s.status === 'BEFORE_REQUEST') &&
+    cls.students.some((s) => s.status === 'BEFORE_REQUEST' && s.isCardRegistered) &&
     selectedStudentIds.length ===
-      cls.students.filter((s) => s.status === 'BEFORE_REQUEST').length;
+      cls.students.filter((s) => s.status === 'BEFORE_REQUEST' && s.isCardRegistered).length;
 
   const hasSelectableStudents =
-    cls.students && cls.students.some((s) => s.status === 'BEFORE_REQUEST');
+    cls.students && cls.students.some((s) => s.status === 'BEFORE_REQUEST' && s.isCardRegistered);
 
   return (
     <React.Fragment>
@@ -96,10 +96,13 @@ export default function PaymentRow({
                       className={styles.studentCheck}
                       onChange={() => onSelectStudent(student.studentId)}
                       checked={selectedStudentIds.includes(student.studentId)}
-                      disabled={student.status !== 'BEFORE_REQUEST'}
+                      disabled={student.status !== 'BEFORE_REQUEST' || !student.isCardRegistered}
                     />
                     <span className={styles.studentName}>
                       {student.studentName}
+                      {!student.isCardRegistered && (
+                        <span className={styles.noCardBadge}>카드미등록</span>
+                      )}
                     </span>
                     <span className={styles.studentAmount}>
                       {student.amount.toLocaleString()}원

--- a/src/app/academy/(with-sidebar)/[academyId]/student/form/components/ExcelRegistrationForm.tsx
+++ b/src/app/academy/(with-sidebar)/[academyId]/student/form/components/ExcelRegistrationForm.tsx
@@ -16,6 +16,7 @@ export default function ExcelRegistrationForm({ academyId }: Props) {
     const router = useRouter();
     const [excelFile, setExcelFile] = useState<File | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isDragging, setIsDragging] = useState(false); // 드래그 상태 추가
 
     // Modal States
     const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
@@ -24,6 +25,35 @@ export default function ExcelRegistrationForm({ academyId }: Props) {
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files[0]) {
             setExcelFile(e.target.files[0]);
+        }
+    };
+
+    const handleDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+
+        const files = e.dataTransfer.files;
+        if (files && files.length > 0) {
+            const file = files[0];
+            const extension = file.name.split('.').pop()?.toLowerCase();
+            if (extension === 'xlsx' || extension === 'xls') {
+                setExcelFile(file);
+            } else {
+                alert('엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.');
+            }
         }
     };
 
@@ -59,7 +89,12 @@ export default function ExcelRegistrationForm({ academyId }: Props) {
     return (
         <div className={styles.excelContainer}>
             {!excelFile ? (
-                <label className={styles.uploadBox}>
+                <label 
+                    className={`${styles.uploadBox} ${isDragging ? styles.dragging : ''}`}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                >
                     <input
                         type="file"
                         accept=".xlsx, .xls"

--- a/src/app/academy/(with-sidebar)/[academyId]/student/form/form.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/student/form/form.module.css
@@ -386,7 +386,8 @@
   background-color: #f9fafb;
 }
 
-.uploadBox:hover {
+.uploadBox:hover,
+.uploadBox.dragging {
   border-color: var(--primary-color);
   background-color: #eff6ff;
 }

--- a/src/app/academy/(with-sidebar)/[academyId]/student/form/form.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/student/form/form.module.css
@@ -73,9 +73,14 @@
 }
 
 .multiSelectWrapper {
-  position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
+}
+
+.relativeWrapper {
+  position: relative;
+  width: 100%;
 }
 
 .multiSelectLabel {
@@ -90,11 +95,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  background-color: white;
+  border: 1px solid var(--divider-color);
+  border-radius: var(--radius-md);
+  min-height: var(--input-height);
+  padding: 8px 16px;
+  font-size: 16px;
+  color: #1f2937;
+  transition: all 0.2s ease;
+  box-sizing: border-box;
+}
+
+.multiSelectBox:hover {
+  background-color: #fafafa;
+}
+
+.multiSelectBox:focus-within {
+  border-color: #a1ccff;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
 }
 
 .arrow {
   margin-left: 8px;
   font-size: 12px;
+  color: #6b7280;
 }
 
 .multiSelectOptionsDropdown {
@@ -102,30 +126,50 @@
   top: calc(100% + 4px);
   left: 0;
   width: 100%;
-
   border: 1px solid var(--divider-color);
   border-radius: var(--radius-md);
   margin-top: 4px;
-  max-height: 150px;
+  max-height: 200px;
   overflow-y: auto;
   background-color: #fff;
+  z-index: 1000;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
 
-  z-index: 9999;
+.multiSelectOptionsDropdown::-webkit-scrollbar {
+  width: 6px;
+}
+.multiSelectOptionsDropdown::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+.multiSelectOptionsDropdown::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 4px;
+}
+.multiSelectOptionsDropdown::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
 }
 
 .multiSelectOption {
-  padding: 8px 12px;
+  padding: 10px 16px;
   cursor: pointer;
   font-size: 14px;
-}
-
-.multiSelectOption:hover {
-  background-color: #f0f0f0;
+  color: #374151;
+  transition: background-color 0.15s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .selected {
-  background-color: var(--primary-color);
-  color: white;
+  background-color: #ffffff !important;
+  color: var(--primary-color) !important;
+  font-weight: 600;
+}
+
+.multiSelectOption:hover {
+  background-color: #f3f4f6 !important;
 }
 
 .cardBox {
@@ -324,7 +368,6 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  /* align-items: center; removed to allow full width for children */
   padding: 20px 0;
 }
 

--- a/src/app/academy/(with-sidebar)/[academyId]/student/form/studentFormLayout.module.css
+++ b/src/app/academy/(with-sidebar)/[academyId]/student/form/studentFormLayout.module.css
@@ -9,7 +9,7 @@
 
 .academyContainer {
     width: 100%;
-    max-width: var(--container-width);
+    max-width: var(--reg-container-width);
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/app/academy/register/academyLayout.module.css
+++ b/src/app/academy/register/academyLayout.module.css
@@ -11,7 +11,7 @@
 
 .academyContainer {
   width: 100%;
-  max-width: var(--reg-container-width);
+  max-width: var(--container-width);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/app/academy/register/academyLayout.module.css
+++ b/src/app/academy/register/academyLayout.module.css
@@ -11,7 +11,7 @@
 
 .academyContainer {
   width: 100%;
-  max-width: var(--container-width);
+  max-width: var(--reg-container-width);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/app/academy/register/components/MultiSelect.tsx
+++ b/src/app/academy/register/components/MultiSelect.tsx
@@ -48,36 +48,38 @@ export default function MultiSelect({
     <div className={styles.multiSelectWrapper} ref={wrapperRef}>
       <label className={styles.multiSelectLabel}>{label}</label>
 
-      {/* 선택 박스 (전역 Input 스타일 재사용) */}
-      <div
-        className={`${inputStyles.input} ${styles.multiSelectBox}`}
-        onClick={() => setOpen((prev) => !prev)}
-      >
-        <span className={styles.placeholder}>
-          {selected.length > 0 ? `${selected.length}개 선택됨` : '선택하세요'}
-        </span>
-        <span className={styles.arrow}>{open ? '▲' : '▼'}</span>
-      </div>
-
-      {/* 옵션 리스트 */}
-      {open && (
-        <div className={styles.multiSelectOptionsDropdown}>
-          {options.map((opt) => (
-            <div
-              key={opt}
-              className={`${styles.multiSelectOption} ${
-                selected.includes(opt) ? styles.selected : ''
-              }`}
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleOption(opt);
-              }}
-            >
-              {opt}
-            </div>
-          ))}
+      <div className={styles.relativeWrapper}>
+        <div
+          className={`${inputStyles.input} ${styles.multiSelectBox}`}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <span className={styles.placeholder}>
+            {selected.length > 0 ? `${selected.length}개 선택됨` : '선택하세요'}
+          </span>
+          <span className={styles.arrow}>{open ? '▲' : '▼'}</span>
         </div>
-      )}
+
+        {open && (
+          <div className={styles.multiSelectOptionsDropdown}>
+            {options
+              .filter((opt) => !selected.includes(opt))
+              .map((opt) => (
+              <div
+                key={opt}
+                className={`${styles.multiSelectOption} ${
+                  selected.includes(opt) ? styles.selected : ''
+                }`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleOption(opt);
+                }}
+              >
+                {opt}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {selected.length > 0 && (
         <div className={styles.selectedTagsContainer}>

--- a/src/app/academy/register/form/form.module.css
+++ b/src/app/academy/register/form/form.module.css
@@ -1,5 +1,5 @@
 .formContainer {
-  width: var(--reg-container-width);
+  width: var(--container-width);
   margin: 0 auto;
   border-radius: var(--radius-sm);
   box-sizing: border-box;

--- a/src/app/academy/register/form/form.module.css
+++ b/src/app/academy/register/form/form.module.css
@@ -1,5 +1,5 @@
 .formContainer {
-  width: var(--container-width);
+  width: var(--reg-container-width);
   margin: 0 auto;
   border-radius: var(--radius-sm);
   box-sizing: border-box;

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -1,0 +1,249 @@
+.container {
+  padding: 40px;
+  max-width: 1200px;
+  margin: 0 auto;
+  font-family: 'Pretendard', sans-serif;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.tableCard {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.table th {
+  background-color: #f9fafb;
+  padding: 16px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #4b5563;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.table td {
+  padding: 16px 24px;
+  font-size: 14px;
+  color: #1f2937;
+  border-bottom: 1px solid #e5e7eb;
+  cursor: pointer;
+}
+
+.table tr:hover td {
+  background-color: #f3f4f6;
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badgePending {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.badgeApproved {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.badgeRejected {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+/* Modal Styles */
+.detailHeader {
+  margin-bottom: 24px;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 16px;
+}
+
+.detailTitle {
+  font-size: 24px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.detailStatus {
+  margin-top: 8px;
+}
+
+.detailContent {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #374151;
+  border-bottom: 1px solid #f3f4f6;
+  padding-bottom: 8px;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.infoLabel {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.infoValue {
+  color: #1f2937;
+}
+
+.imageGrid {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.academyImage {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+/* Preset Buttons for Rejection */
+.presetContainer {
+  display: flex;
+  flex-direction: column; /* 세로 배치로 변경 */
+  gap: 8px;
+  margin-top: 12px;
+  margin-bottom: 20px;
+}
+
+.presetBtn {
+  width: 100%; /* 너비 꽉 채우기 */
+  padding: 12px 16px; /* 패딩 넉넉하게 */
+  border-radius: 8px; /* 둥근 사각형으로 변경 */
+  border: 1px solid #e5e7eb;
+  background-color: white;
+  color: #4b5563;
+  font-size: 14px; /* 글자 크기 약간 키움 */
+  font-weight: 500;
+  text-align: left; /* 텍스트 왼쪽 정렬 */
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.presetBtn:hover {
+  background-color: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.presetBtnActive {
+  background-color: #eff6ff;
+  border-color: #3b82f6;
+  color: #1d4ed8;
+  font-weight: 600;
+  box-shadow: 0 0 0 1px #3b82f6;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.btnApprove {
+  background-color: #2563eb;
+  color: white;
+}
+.btnApprove:hover { background-color: #1d4ed8; }
+
+.btnReject {
+  background-color: #ef4444;
+  color: white;
+}
+.btnReject:hover { background-color: #dc2626; }
+
+.btnCancel {
+  background-color: #f3f4f6;
+  color: #4b5563;
+}
+.btnCancel:hover { background-color: #e5e7eb; }
+
+/* Rejection Modal Input */
+.rejectionInput {
+  width: 100%;
+  min-height: 120px;
+  padding: 16px;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  resize: none;
+  font-size: 16px; /* 폰트 크기 증가 */
+  font-family: 'Pretendard', sans-serif; /* 폰트 통일 */
+  font-weight: 500; /* 글씨 두께 증가 */
+  line-height: 1.5;
+  background-color: #f9fafb;
+  color: #1f2937; /* 텍스트 색상 명시 */
+  box-sizing: border-box; /* 패딩 포함하여 너비 계산 */
+  display: block; /* 블록 요소로 변경 */
+  margin-left: auto; /* 좌우 자동 여백으로 중앙 정렬 보장 */
+  margin-right: auto;
+}
+
+.rejectionInput::placeholder {
+  color: #9ca3af;
+  font-weight: 400; /* Placeholder는 약간 얇게 */
+}
+
+.rejectionInput:focus {
+  outline: 2px solid var(--primary-color, #2563eb);
+  background-color: white;
+}

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -1,21 +1,72 @@
 .container {
-  padding: 40px;
-  max-width: 1200px;
+  padding: 40px 60px;
+  width: 100%;
+  max-width: 1080px;
   margin: 0 auto;
   font-family: 'Pretendard', sans-serif;
+  box-sizing: border-box;
 }
 
 .header {
+  position: relative;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  margin-bottom: 32px;
+  margin-bottom: 40px;
 }
 
 .title {
-  font-size: 28px;
+  font-size: 26px;
   font-weight: 700;
   color: #111827;
+  margin: 0;
+}
+
+.refreshBtn {
+  position: absolute;
+  right: 0;
+  padding: 8px 16px;
+  background-color: #f3f4f6;
+  color: #4b5563;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none; /* 보더라인 제거 */
+  transition: all 0.2s;
+}
+
+.refreshBtn:hover {
+  background-color: #e5e7eb;
+}
+
+.tabContainer {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 0;
+}
+
+.tab {
+  padding: 12px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #6b7280;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+  background: none;
+  border: none;
+}
+
+.tab:hover {
+  color: #111827;
+}
+
+.activeTab {
+  color: #2563eb;
+  border-bottom: 2px solid #2563eb;
 }
 
 .tableCard {
@@ -32,20 +83,37 @@
   text-align: left;
 }
 
-.table th {
-  background-color: #f9fafb;
-  padding: 16px 24px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #4b5563;
+.table th, .table td {
+  padding: 20px 24px;
+  font-size: 15px;
   border-bottom: 1px solid #e5e7eb;
 }
 
+.table th {
+  background-color: #f9fafb;
+  font-weight: 700;
+  color: #374151;
+  border-bottom: 2px solid #e5e7eb;
+  text-align: left;
+}
+
+/* 컬럼 너비 고정 및 정렬 */
+.table th:nth-child(1), .table td:nth-child(1) { width: 60px; text-align: center; } /* ID 더 슬림하게 */
+.table th:nth-child(2), .table td:nth-child(2) { width: 200px; } /* 학원명 줄임 */
+.table th:nth-child(3), .table td:nth-child(3) { 
+  width: 120px; 
+  text-align: center; 
+} /* 상태 조금 슬림하게 */
+.table th:nth-child(4), .table td:nth-child(4) { width: auto; } /* 거절 사유가 나머지 공간 다 사용 */
+
+.table td:nth-child(3) {
+  display: table-cell; /* td 기본값 유지 */
+  text-align: center;  /* 내부 인라인 요소(badge) 중앙 정렬 */
+  vertical-align: middle;
+}
+
 .table td {
-  padding: 16px 24px;
-  font-size: 14px;
   color: #1f2937;
-  border-bottom: 1px solid #e5e7eb;
   cursor: pointer;
 }
 
@@ -78,15 +146,48 @@
 
 /* Modal Styles */
 .detailHeader {
-  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 0;
   border-bottom: 1px solid #e5e7eb;
-  padding-bottom: 16px;
+  padding-bottom: 16px; /* 패딩 복구 */
 }
 
 .detailTitle {
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 700;
   color: #111827;
+}
+
+/* Lightbox Styles */
+.lightboxOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  cursor: zoom-out;
+}
+
+.lightboxImage {
+  max-width: 90%;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 0 20px rgba(0,0,0,0.5);
+  cursor: default;
+}
+
+.lightboxClose {
+  position: absolute;
+  top: 30px;
+  right: 40px;
+  color: white;
+  font-size: 32px;
+  cursor: pointer;
 }
 
 .detailStatus {
@@ -141,6 +242,26 @@
   object-fit: cover;
   border-radius: 8px;
   border: 1px solid #e5e7eb;
+}
+
+.certificateWrapper {
+  margin-top: 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  background-color: #f9fafb;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-width: 600px;
+}
+
+.certificateImage {
+  max-width: 100%;
+  max-height: 400px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 /* Preset Buttons for Rejection */
@@ -213,10 +334,72 @@
 .btnCancel {
   background-color: #f3f4f6;
   color: #4b5563;
+  border: none; /* 보더라인 제거 */
 }
 .btnCancel:hover { background-color: #e5e7eb; }
 
 /* Rejection Modal Input */
+/* Modal Overlay & Layout */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+
+.modalContent {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 1000px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 32px;
+  border: 1px solid #e5e7eb;
+}
+
+/* 커스텀 스크롤바 디자인 */
+.modalContent::-webkit-scrollbar {
+  width: 12px; /* 여백 확보를 위해 전체 폭을 조금 넓히고 핸들은 얇게 조절 */
+}
+
+.modalContent::-webkit-scrollbar-track {
+  background: transparent;
+  margin: 12px 0; /* 상하단 여백을 주어 둥근 모서리 밖으로 나가지 않게 함 */
+}
+
+.modalContent::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 10px;
+  border: 3px solid white; /* 배경색과 같은 보더를 주어 핸들을 시각적으로 얇게 만듦 */
+}
+
+.modalContent::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 100px;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+.rejectionText {
+  margin-top: 12px;
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.table td[style*="color: #6b7280"] { /* Reason column gray color */
+  color: #6b7280;
+}
+
 .rejectionInput {
   width: 100%;
   min-height: 120px;

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -42,10 +42,39 @@
 
 .tabContainer {
   display: flex;
-  gap: 8px;
+  justify-content: space-between;
+  align-items: flex-end;
   margin-bottom: 24px;
   border-bottom: 1px solid #e5e7eb;
-  padding-bottom: 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.searchContainer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  background-color: #f3f4f6;
+  padding: 6px 12px;
+  border-radius: 8px;
+  width: 280px;
+}
+
+.searchInput {
+  border: none;
+  background: none;
+  font-size: 14px;
+  color: #1f2937;
+  width: 100%;
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: #9ca3af;
 }
 
 .tab {
@@ -135,8 +164,8 @@
 }
 
 .badgeApproved {
-  background-color: #dcfce7;
-  color: #166534;
+  background-color: #e0f2fe; /* Light blue */
+  color: #2563eb; /* Darker blue */
 }
 
 .badgeRejected {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -17,8 +17,11 @@ export default function AdminPage() {
   const [academies, setAcademies] = useState<AcademyListResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   
-  // 탭 상태 (PENDING/REJECTED)
-  const [activeTab, setActiveTab] = useState<'PENDING' | 'REJECTED'>('PENDING');
+  // 탭 상태 (ALL/PENDING/REJECTED)
+  const [activeTab, setActiveTab] = useState<'ALL' | 'PENDING' | 'REJECTED'>('ALL');
+  
+  // 검색어 상태
+  const [searchTerm, setSearchTerm] = useState('');
 
   // 상세 모달 상태
   const [selectedAcademyId, setSelectedAcademyId] = useState<number | null>(null);
@@ -42,9 +45,11 @@ export default function AdminPage() {
     setIsLoading(true);
     try {
       const response = 
-        activeTab === 'PENDING' 
-          ? await adminService.getPendingAcademies(0, 50)
-          : await adminService.getRejectedAcademies(0, 50);
+        activeTab === 'ALL'
+          ? await adminService.getAllAcademies(0, 50)
+          : activeTab === 'PENDING' 
+            ? await adminService.getPendingAcademies(0, 50)
+            : await adminService.getRejectedAcademies(0, 50);
       setAcademies(response.content);
     } catch (error) {
       console.error('목록 로딩 실패:', error);
@@ -56,7 +61,13 @@ export default function AdminPage() {
 
   useEffect(() => {
     fetchList();
+    setSearchTerm(''); // 탭 변경 시 검색어 초기화
   }, [fetchList, activeTab]);
+
+  // 검색 필터링 로직
+  const filteredAcademies = academies.filter(academy => 
+    academy.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
 
   // 상세 모달 열기
   const openDetail = async (id: number) => {
@@ -130,20 +141,23 @@ export default function AdminPage() {
     }
   };
 
-  const statusBadgeClass = (status: string) => {
-      switch(status) {
-          case 'APPROVED': return styles.badgeApproved;
-          case 'REJECTED': return styles.badgeRejected;
-          default: return styles.badgePending;
-      }
+    // 상태 라벨 헬퍼
+  const statusLabel = (status: string) => {
+    switch (status) {
+      case 'PENDING': return '대기 중';
+      case 'REJECTED': return '반려됨';
+      case 'APPROVED': return '승인됨';
+      default: return status;
+    }
   };
 
-  const statusLabel = (status: string) => {
-      switch(status) {
-          case 'APPROVED': return '승인됨';
-          case 'REJECTED': return '반려됨';
-          default: return '대기중'; 
-      }
+  const statusBadgeClass = (status: string) => {
+    switch (status) {
+      case 'PENDING': return styles.badgePending;
+      case 'REJECTED': return styles.badgeRejected;
+      case 'APPROVED': return styles.badgeApproved;
+      default: return '';
+    }
   };
 
   return (
@@ -155,18 +169,40 @@ export default function AdminPage() {
 
       {/* 탭 네비게이션 */}
       <div className={styles.tabContainer}>
-        <button 
-          className={`${styles.tab} ${activeTab === 'PENDING' ? styles.activeTab : ''}`}
-          onClick={() => setActiveTab('PENDING')}
-        >
-          승인 대기 중
-        </button>
-        <button 
-          className={`${styles.tab} ${activeTab === 'REJECTED' ? styles.activeTab : ''}`}
-          onClick={() => setActiveTab('REJECTED')}
-        >
-          반려됨
-        </button>
+        <div className={styles.tabs}>
+            <button 
+            className={`${styles.tab} ${activeTab === 'ALL' ? styles.activeTab : ''}`}
+            onClick={() => setActiveTab('ALL')}
+            >
+            전체
+            </button>
+            <button 
+            className={`${styles.tab} ${activeTab === 'PENDING' ? styles.activeTab : ''}`}
+            onClick={() => setActiveTab('PENDING')}
+            >
+            승인 대기 중
+            </button>
+            <button 
+            className={`${styles.tab} ${activeTab === 'REJECTED' ? styles.activeTab : ''}`}
+            onClick={() => setActiveTab('REJECTED')}
+            >
+            반려됨
+            </button>
+        </div>
+
+        <div className={styles.searchContainer}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8"></circle>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <input 
+                type="text" 
+                className={styles.searchInput} 
+                placeholder="학원명으로 검색..." 
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+            />
+        </div>
       </div>
 
       <div className={styles.tableCard}>
@@ -180,17 +216,22 @@ export default function AdminPage() {
             </tr>
           </thead>
           <tbody>
-            {!isLoading && academies.length === 0 && (
+            {!isLoading && filteredAcademies.length === 0 && (
                 <tr>
                     <td colSpan={4} className={styles.emptyState}>
-                        {activeTab === 'PENDING' ? '승인 대기 중인 학원이 없습니다.' : '반려된 학원이 없습니다.'}
+                        {searchTerm ? '검색 결과가 없습니다.' : (
+                            activeTab === 'ALL' ? '등록된 학원이 없습니다.' :
+                            activeTab === 'PENDING' ? '승인 대기 중인 학원이 없습니다.' : '반려된 학원이 없습니다.'
+                        )}
                     </td>
                 </tr>
             )}
-            {!isLoading && academies.map((academy) => (
-              <tr key={academy.academyId} onClick={() => openDetail(academy.academyId)}>
-                <td>{academy.academyId}</td>
-                <td>{academy.name}</td>
+            {!isLoading && filteredAcademies.map((academy) => {
+              const displayId = academy.id || academy.academyId;
+              return (
+                <tr key={displayId} onClick={() => displayId && openDetail(displayId)}>
+                  <td>{displayId || '-'}</td>
+                  <td>{academy.name}</td>
                 <td>
                   <span className={`${styles.badge} ${statusBadgeClass(academy.approvalStatus)}`}>
                     {statusLabel(academy.approvalStatus)}
@@ -200,7 +241,7 @@ export default function AdminPage() {
                     {academy.approvalStatus === 'REJECTED' ? academy.rejectionReason : '-'}
                 </td>
               </tr>
-            ))}
+            ); })}
           </tbody>
         </table>
       </div>
@@ -230,9 +271,19 @@ export default function AdminPage() {
                           )}
 
                           <div className={styles.section}>
+                              <div className={styles.sectionTitle}>등록자 정보</div>
+                              <div className={styles.infoGrid}>
+                                  <span className={styles.infoLabel}>이름</span>
+                                  <span className={styles.infoValue}>{detailData.userName || '-'}</span>
+                                  <span className={styles.infoLabel}>연락처</span>
+                                  <span className={styles.infoValue}>{detailData.userPhoneNumber || '-'}</span>
+                              </div>
+                          </div>
+
+                          <div className={styles.section}>
                               <div className={styles.sectionTitle}>기본 정보</div>
                               <div className={styles.infoGrid}>
-                                  <span className={styles.infoLabel}>연락처</span>
+                                  <span className={styles.infoLabel}>학원 연락처</span>
                                   <span className={styles.infoValue}>{detailData.phoneNumber || '-'}</span>
                                   <span className={styles.infoLabel}>주소</span>
                                   <span className={styles.infoValue}>
@@ -270,6 +321,24 @@ export default function AdminPage() {
                                   <span className={styles.infoLabel}>상세 소개</span>
                                   <span className={styles.infoValue} style={{whiteSpace: 'pre-wrap'}}>
                                       {detailData.detailInfo || '-'}
+                                  </span>
+                              </div>
+                          </div>
+
+                          <div className={styles.section}>
+                              <div className={styles.sectionTitle}>대상 연령 및 과목</div>
+                              <div className={styles.infoGrid}>
+                                  <span className={styles.infoLabel}>연령대</span>
+                                  <span className={styles.infoValue}>
+                                      {detailData.ages && detailData.ages.length > 0 
+                                          ? detailData.ages.map(a => a.ageCode).join(', ') 
+                                          : '-'}
+                                  </span>
+                                  <span className={styles.infoLabel}>수강 과목</span>
+                                  <span className={styles.infoValue}>
+                                      {detailData.subjects && detailData.subjects.length > 0 
+                                          ? detailData.subjects.map(s => `${s.detailSubject}(${s.mainSubjectCode})`).join(', ') 
+                                          : '-'}
                                   </span>
                               </div>
                           </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -17,33 +17,46 @@ export default function AdminPage() {
   const [academies, setAcademies] = useState<AcademyListResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   
+  // 탭 상태 (PENDING/REJECTED)
+  const [activeTab, setActiveTab] = useState<'PENDING' | 'REJECTED'>('PENDING');
+
   // 상세 모달 상태
   const [selectedAcademyId, setSelectedAcademyId] = useState<number | null>(null);
   const [detailData, setDetailData] = useState<AcademyResponse | null>(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
+  // 승인 모달 상태
+  const [isApproveOpen, setIsApproveOpen] = useState(false);
+  
   // 반려 모달 상태
   const [isRejectOpen, setIsRejectOpen] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
 
+  // 이미지 미리보기(라이트박스) 상태
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState('');
+
   const fetchList = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await adminService.getPendingAcademies(0, 50); // 일단 첫 페이지만 50개
+      const response = 
+        activeTab === 'PENDING' 
+          ? await adminService.getPendingAcademies(0, 50)
+          : await adminService.getRejectedAcademies(0, 50);
       setAcademies(response.content);
     } catch (error) {
       console.error('목록 로딩 실패:', error);
-      toast.error('대기 목록을 불러오지 못했습니다.');
+      toast.error('목록을 불러오지 못했습니다.');
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [activeTab]);
 
   useEffect(() => {
     fetchList();
-  }, [fetchList]);
+  }, [fetchList, activeTab]);
 
   // 상세 모달 열기
   const openDetail = async (id: number) => {
@@ -61,15 +74,20 @@ export default function AdminPage() {
     }
   };
 
+  // 승인 모달 열기
+  const openApproveModal = () => {
+    setIsApproveOpen(true);
+  };
+
   // 승인 처리
   const handleApprove = async () => {
     if (!selectedAcademyId) return;
-    if (!confirm('정말 승인하시겠습니까?')) return;
 
     setIsProcessing(true);
     try {
       await adminService.approveAcademy(selectedAcademyId);
       toast.success('승인되었습니다.');
+      setIsApproveOpen(false);
       setIsDetailOpen(false);
       fetchList(); // 목록 갱신
     } catch (error: any) {
@@ -132,7 +150,23 @@ export default function AdminPage() {
     <div className={styles.container}>
       <div className={styles.header}>
         <h1 className={styles.title}>학원 승인 관리</h1>
-        <button className={styles.btnCancel} onClick={fetchList}>새로고침</button>
+        <button className={styles.refreshBtn} onClick={fetchList}>새로고침</button>
+      </div>
+
+      {/* 탭 네비게이션 */}
+      <div className={styles.tabContainer}>
+        <button 
+          className={`${styles.tab} ${activeTab === 'PENDING' ? styles.activeTab : ''}`}
+          onClick={() => setActiveTab('PENDING')}
+        >
+          승인 대기 중
+        </button>
+        <button 
+          className={`${styles.tab} ${activeTab === 'REJECTED' ? styles.activeTab : ''}`}
+          onClick={() => setActiveTab('REJECTED')}
+        >
+          반려됨
+        </button>
       </div>
 
       <div className={styles.tableCard}>
@@ -148,21 +182,21 @@ export default function AdminPage() {
           <tbody>
             {!isLoading && academies.length === 0 && (
                 <tr>
-                    <td colSpan={4} style={{textAlign: 'center', padding: '40px'}}>
-                        대기 중인 학원이 없습니다.
+                    <td colSpan={4} className={styles.emptyState}>
+                        {activeTab === 'PENDING' ? '승인 대기 중인 학원이 없습니다.' : '반려된 학원이 없습니다.'}
                     </td>
                 </tr>
             )}
-            {academies.map((academy) => (
+            {!isLoading && academies.map((academy) => (
               <tr key={academy.academyId} onClick={() => openDetail(academy.academyId)}>
                 <td>{academy.academyId}</td>
-                <td style={{fontWeight: 600}}>{academy.name}</td>
+                <td>{academy.name}</td>
                 <td>
                   <span className={`${styles.badge} ${statusBadgeClass(academy.approvalStatus)}`}>
                     {statusLabel(academy.approvalStatus)}
                   </span>
                 </td>
-                <td style={{color: '#6b7280'}}>
+                <td className={styles.reasonText}>
                     {academy.approvalStatus === 'REJECTED' ? academy.rejectionReason : '-'}
                 </td>
               </tr>
@@ -171,15 +205,10 @@ export default function AdminPage() {
         </table>
       </div>
 
-      {/* 상세 정보 모달 (Custom Implementation for richer content) */}
       {isDetailOpen && (
-          <div className="overlay" style={{
-              position: 'fixed', inset: 0, backgroundColor: 'rgba(0,0,0,0.5)', 
-              display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000
-          }} onClick={() => setIsDetailOpen(false)}>
+          <div className={styles.modalOverlay} onClick={() => setIsDetailOpen(false)}>
               <div 
-                  className={styles.tableCard} 
-                  style={{ width: '90%', maxWidth: '800px', maxHeight: '90vh', overflowY: 'auto', padding: '32px' }}
+                  className={styles.modalContent} 
                   onClick={e => e.stopPropagation()}
               >
                   {isDetailLoading || !detailData ? (
@@ -193,18 +222,16 @@ export default function AdminPage() {
                                     {statusLabel(detailData.approvalStatus)}
                                   </span>
                               </div>
-                              {detailData.approvalStatus === 'REJECTED' && (
-                                  <div style={{marginTop: '12px', color: '#dc2626', fontWeight: 500}}>
-                                      거절 사유: {detailData.rejectionReason}
-                                  </div>
-                              )}
                           </div>
+                          {detailData.approvalStatus === 'REJECTED' && (
+                              <div className={styles.rejectionText} style={{ marginTop: '-8px', marginBottom: '12px' }}>
+                                  거절 사유: {detailData.rejectionReason}
+                              </div>
+                          )}
 
                           <div className={styles.section}>
                               <div className={styles.sectionTitle}>기본 정보</div>
                               <div className={styles.infoGrid}>
-                                  <span className={styles.infoLabel}>ID</span>
-                                  <span className={styles.infoValue}>{detailData.academyId}</span>
                                   <span className={styles.infoLabel}>연락처</span>
                                   <span className={styles.infoValue}>{detailData.phoneNumber || '-'}</span>
                                   <span className={styles.infoLabel}>주소</span>
@@ -212,6 +239,26 @@ export default function AdminPage() {
                                       {detailData.baseAddress || detailData.address || '-'} 
                                       {detailData.detailAddress ? ` ${detailData.detailAddress}` : ''}
                                   </span>
+                              </div>
+                          </div>
+
+                          {/* 사업자등록증 섹션 추가 */}
+                          <div className={styles.section}>
+                              <div className={styles.sectionTitle}>사업자등록증</div>
+                              <div className={styles.certificateWrapper}>
+                                  {detailData.certificate ? (
+                                      <img 
+                                          src={detailData.certificate} 
+                                          alt="사업자등록증" 
+                                          className={styles.certificateImage}
+                                          onClick={() => {
+                                              setPreviewUrl(detailData.certificate!);
+                                              setIsPreviewOpen(true);
+                                          }}
+                                      />
+                                  ) : (
+                                      <div style={{ color: '#9ca3af', padding: '20px' }}>등록된 서류가 없습니다.</div>
+                                  )}
                               </div>
                           </div>
 
@@ -239,7 +286,7 @@ export default function AdminPage() {
                           )}
 
                           <div className={styles.actions}>
-                              <button className={styles.btnCancel} onClick={() => setIsDetailOpen(false)}>닫기</button>
+                              <button className={`${styles.btn} ${styles.btnCancel}`} onClick={() => setIsDetailOpen(false)}>닫기</button>
                               {detailData.approvalStatus === 'PENDING' && (
                                   <>
                                     <button 
@@ -251,7 +298,7 @@ export default function AdminPage() {
                                     </button>
                                     <button 
                                         className={`${styles.btn} ${styles.btnApprove}`} 
-                                        onClick={handleApprove}
+                                        onClick={openApproveModal}
                                         disabled={isProcessing}
                                     >
                                         승인
@@ -293,6 +340,29 @@ export default function AdminPage() {
               autoFocus
           />
       </CustomModal>
+
+      <CustomModal
+          isOpen={isApproveOpen}
+          onClose={() => setIsApproveOpen(false)}
+          title="승인 확인"
+          description={`'${detailData?.name}' 학원의 등록 신청을 승인하시겠습니까?`}
+          actionText={isProcessing ? "처리 중..." : "승인"}
+          onAction={handleApprove}
+          cancelText="취소"
+      />
+      
+      {/* 이미지 라이트박스 모달 */}
+      {isPreviewOpen && (
+          <div className={styles.lightboxOverlay} onClick={() => setIsPreviewOpen(false)}>
+              <span className={styles.lightboxClose}>&times;</span>
+              <img 
+                  src={previewUrl} 
+                  alt="사업자등록증 원본" 
+                  className={styles.lightboxImage} 
+                  onClick={(e) => e.stopPropagation()} 
+              />
+          </div>
+      )}
 
     </div>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import styles from './admin.module.css';
+import { adminService } from '@/services/adminService';
+import { AcademyListResponse, AcademyResponse } from '@/types/admin';
+import { toast } from 'sonner';
+import CustomModal from '@/components/common/CustomModal';
+
+const REJECTION_REASONS = [
+  '제출된 사업자등록증이 식별되지 않습니다.',
+  '학원명과 사업자등록증의 상호가 일치하지 않습니다.',
+  '학원 주소와 사업자등록증의 주소가 일치하지 않습니다.',
+];
+
+export default function AdminPage() {
+  const [academies, setAcademies] = useState<AcademyListResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // 상세 모달 상태
+  const [selectedAcademyId, setSelectedAcademyId] = useState<number | null>(null);
+  const [detailData, setDetailData] = useState<AcademyResponse | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+
+  // 반려 모달 상태
+  const [isRejectOpen, setIsRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const fetchList = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await adminService.getPendingAcademies(0, 50); // 일단 첫 페이지만 50개
+      setAcademies(response.content);
+    } catch (error) {
+      console.error('목록 로딩 실패:', error);
+      toast.error('대기 목록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  // 상세 모달 열기
+  const openDetail = async (id: number) => {
+    setSelectedAcademyId(id);
+    setIsDetailOpen(true);
+    setIsDetailLoading(true);
+    try {
+      const data = await adminService.getAcademyDetail(id);
+      setDetailData(data);
+    } catch (error) {
+      toast.error('상세 정보를 불러오지 못했습니다.');
+      setIsDetailOpen(false);
+    } finally {
+      setIsDetailLoading(false);
+    }
+  };
+
+  // 승인 처리
+  const handleApprove = async () => {
+    if (!selectedAcademyId) return;
+    if (!confirm('정말 승인하시겠습니까?')) return;
+
+    setIsProcessing(true);
+    try {
+      await adminService.approveAcademy(selectedAcademyId);
+      toast.success('승인되었습니다.');
+      setIsDetailOpen(false);
+      fetchList(); // 목록 갱신
+    } catch (error: any) {
+        const msg = error.response?.data?.message || '승인 처리 실패';
+        toast.error(msg);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  // 반려 모달 열기
+  const openRejectModal = () => {
+    setRejectReason('');
+    setIsRejectOpen(true);
+  };
+
+  const handlePresetClick = (reason: string) => {
+    setRejectReason(reason);
+  };
+
+  // 반려 처리
+  const handleReject = async () => {
+    if (!selectedAcademyId || !rejectReason.trim()) {
+        toast.error('거절 사유를 입력해주세요.');
+        return;
+    }
+
+    setIsProcessing(true);
+    try {
+      await adminService.rejectAcademy(selectedAcademyId, rejectReason);
+      toast.success('반려되었습니다.');
+      setIsRejectOpen(false);
+      setIsDetailOpen(false); // 상세 모달도 닫기
+      fetchList(); // 목록 갱신
+    } catch (error: any) {
+        const msg = error.response?.data?.message || '반려 처리 실패';
+        toast.error(msg);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const statusBadgeClass = (status: string) => {
+      switch(status) {
+          case 'APPROVED': return styles.badgeApproved;
+          case 'REJECTED': return styles.badgeRejected;
+          default: return styles.badgePending;
+      }
+  };
+
+  const statusLabel = (status: string) => {
+      switch(status) {
+          case 'APPROVED': return '승인됨';
+          case 'REJECTED': return '반려됨';
+          default: return '대기중'; 
+      }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>학원 승인 관리</h1>
+        <button className={styles.btnCancel} onClick={fetchList}>새로고침</button>
+      </div>
+
+      <div className={styles.tableCard}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>학원명</th>
+              <th>상태</th>
+              <th>거절 사유</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!isLoading && academies.length === 0 && (
+                <tr>
+                    <td colSpan={4} style={{textAlign: 'center', padding: '40px'}}>
+                        대기 중인 학원이 없습니다.
+                    </td>
+                </tr>
+            )}
+            {academies.map((academy) => (
+              <tr key={academy.academyId} onClick={() => openDetail(academy.academyId)}>
+                <td>{academy.academyId}</td>
+                <td style={{fontWeight: 600}}>{academy.name}</td>
+                <td>
+                  <span className={`${styles.badge} ${statusBadgeClass(academy.approvalStatus)}`}>
+                    {statusLabel(academy.approvalStatus)}
+                  </span>
+                </td>
+                <td style={{color: '#6b7280'}}>
+                    {academy.approvalStatus === 'REJECTED' ? academy.rejectionReason : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 상세 정보 모달 (Custom Implementation for richer content) */}
+      {isDetailOpen && (
+          <div className="overlay" style={{
+              position: 'fixed', inset: 0, backgroundColor: 'rgba(0,0,0,0.5)', 
+              display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000
+          }} onClick={() => setIsDetailOpen(false)}>
+              <div 
+                  className={styles.tableCard} 
+                  style={{ width: '90%', maxWidth: '800px', maxHeight: '90vh', overflowY: 'auto', padding: '32px' }}
+                  onClick={e => e.stopPropagation()}
+              >
+                  {isDetailLoading || !detailData ? (
+                      <div>로딩 중...</div>
+                  ) : (
+                      <div className={styles.detailContent}>
+                          <div className={styles.detailHeader}>
+                              <div className={styles.detailTitle}>{detailData.name}</div>
+                              <div className={styles.detailStatus}>
+                                  <span className={`${styles.badge} ${statusBadgeClass(detailData.approvalStatus)}`}>
+                                    {statusLabel(detailData.approvalStatus)}
+                                  </span>
+                              </div>
+                              {detailData.approvalStatus === 'REJECTED' && (
+                                  <div style={{marginTop: '12px', color: '#dc2626', fontWeight: 500}}>
+                                      거절 사유: {detailData.rejectionReason}
+                                  </div>
+                              )}
+                          </div>
+
+                          <div className={styles.section}>
+                              <div className={styles.sectionTitle}>기본 정보</div>
+                              <div className={styles.infoGrid}>
+                                  <span className={styles.infoLabel}>ID</span>
+                                  <span className={styles.infoValue}>{detailData.academyId}</span>
+                                  <span className={styles.infoLabel}>연락처</span>
+                                  <span className={styles.infoValue}>{detailData.phoneNumber || '-'}</span>
+                                  <span className={styles.infoLabel}>주소</span>
+                                  <span className={styles.infoValue}>
+                                      {detailData.baseAddress || detailData.address || '-'} 
+                                      {detailData.detailAddress ? ` ${detailData.detailAddress}` : ''}
+                                  </span>
+                              </div>
+                          </div>
+
+                          <div className={styles.section}>
+                              <div className={styles.sectionTitle}>학원 소개</div>
+                              <div className={styles.infoGrid}>
+                                  <span className={styles.infoLabel}>한줄 소개</span>
+                                  <span className={styles.infoValue}>{detailData.briefInfo || '-'}</span>
+                                  <span className={styles.infoLabel}>상세 소개</span>
+                                  <span className={styles.infoValue} style={{whiteSpace: 'pre-wrap'}}>
+                                      {detailData.detailInfo || '-'}
+                                  </span>
+                              </div>
+                          </div>
+                          
+                          {(detailData.imageUrls && detailData.imageUrls.length > 0) && (
+                            <div className={styles.section}>
+                                <div className={styles.sectionTitle}>이미지</div>
+                                <div className={styles.imageGrid}>
+                                    {detailData.imageUrls.map((url, idx) => (
+                                        <img key={idx} src={url} alt="Academy" className={styles.academyImage} />
+                                    ))}
+                                </div>
+                            </div>
+                          )}
+
+                          <div className={styles.actions}>
+                              <button className={styles.btnCancel} onClick={() => setIsDetailOpen(false)}>닫기</button>
+                              {detailData.approvalStatus === 'PENDING' && (
+                                  <>
+                                    <button 
+                                        className={`${styles.btn} ${styles.btnReject}`} 
+                                        onClick={openRejectModal}
+                                        disabled={isProcessing}
+                                    >
+                                        반려
+                                    </button>
+                                    <button 
+                                        className={`${styles.btn} ${styles.btnApprove}`} 
+                                        onClick={handleApprove}
+                                        disabled={isProcessing}
+                                    >
+                                        승인
+                                    </button>
+                                  </>
+                              )}
+                          </div>
+                      </div>
+                  )}
+              </div>
+          </div>
+      )}
+
+      <CustomModal
+          isOpen={isRejectOpen}
+          onClose={() => setIsRejectOpen(false)}
+          title="승인 반려"
+          description="반려 사유를 입력해주세요."
+          actionText={isProcessing ? "처리 중..." : "반려"}
+          onAction={handleReject}
+      >
+          <div className={styles.presetContainer}>
+            {REJECTION_REASONS.map((reason, idx) => (
+              <button
+                key={idx}
+                className={`${styles.presetBtn} ${rejectReason === reason ? styles.presetBtnActive : ''}`}
+                onClick={() => handlePresetClick(reason)}
+              >
+                {reason}
+              </button>
+            ))}
+          </div>
+
+          <textarea 
+              className={styles.rejectionInput}
+              placeholder="반려 사유를 입력하세요."
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              autoFocus
+          />
+      </CustomModal>
+
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,7 @@
   --radius-sm: 8px;
 
   --container-width: 450px;
+  --reg-container-width: 800px; /* 등록 화면용 너비 */
 
   --primary-color: #007aff;
   --primary-hover: #0056b3;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
   --radius-sm: 8px;
 
   --container-width: 450px;
-  --reg-container-width: 800px; /* 등록 화면용 너비 */
+  --reg-container-width: 700px; /* 등록 및 관리 화면용 너비 */
 
   --primary-color: #007aff;
   --primary-hover: #0056b3;

--- a/src/components/common/CustomModal.module.css
+++ b/src/components/common/CustomModal.module.css
@@ -15,7 +15,7 @@
   background-color: white;
   width: 90%;
   max-width: 454px;
-  max-height: 334px;
+  /* max-height: 334px; removed to fit content */
   padding: 20px 20px;
   border-radius: 12px;
   text-align: center;

--- a/src/components/common/CustomModal.tsx
+++ b/src/components/common/CustomModal.tsx
@@ -7,10 +7,11 @@ interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
-  description: string;
+  description?: string;
   actionText: string;
   onAction: () => void;
   cancelText?: string;
+  children?: React.ReactNode;
 }
 
 export default function CustomModal({
@@ -21,17 +22,18 @@ export default function CustomModal({
   actionText,
   onAction,
   cancelText = '다음에',
+  children,
 }: ModalProps) {
   if (!isOpen) return null;
 
   return (
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
-        <h3>안내</h3>
+        <h3 className={styles.mainText} style={{marginBottom: description ? '8px' : '24px'}}>{title}</h3>
 
-        <div className={styles.body}>
-          <p className={styles.mainText}>{title}</p>
-          <p className={styles.subText}>{description}</p>
+        <div className={styles.body} style={{marginTop: '20px', marginBottom: '32px', marginLeft: '20px', marginRight: '20px'}}>
+          {description && <p className={styles.subText}>{description}</p>}
+          {children}
         </div>
 
         <div className={styles.footer}>

--- a/src/components/common/Input.module.css
+++ b/src/components/common/Input.module.css
@@ -7,7 +7,20 @@
   font-size: 16px;
   box-sizing: border-box;
   outline: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+  color: #1f2937;
+}
+
+.input[type="time"] {
+  font-family: 'Roboto', 'Noto Sans KR', sans-serif;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+  color: #111;
+}
+
+.input::placeholder {
+  color: #9ca3af;
+  font-family: inherit;
 }
 
 .label {

--- a/src/components/common/Select.module.css
+++ b/src/components/common/Select.module.css
@@ -18,16 +18,23 @@
   align-items: center;
   justify-content: space-between;
   background-color: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-size: 14px;
-  color: #333;
-  transition: border-color 0.2s;
+  border: 1px solid var(--divider-color);
+  border-radius: var(--radius-md);
+  height: var(--input-height);
+  padding: 0 16px;
+  font-size: 16px;
+  color: #1f2937;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
 }
 
 .selectBox:hover {
-  border-color: #d1d5db;
+  background-color: #fafafa;
+}
+
+.selectBox:focus-within {
+  border-color: #a1ccff;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
 }
 
 .arrow {

--- a/src/hooks/usePayment.ts
+++ b/src/hooks/usePayment.ts
@@ -101,7 +101,7 @@ export const usePayment = (academyId: string) => {
   ) => {
     if (e.target.checked) {
       const selectableStudents = students.filter(
-        (s) => s.status === 'BEFORE_REQUEST'
+        (s) => s.status === 'BEFORE_REQUEST' && s.isCardRegistered
       );
       setSelectedStudentIds(selectableStudents.map((s) => s.studentId));
     } else {

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -23,7 +23,7 @@ export const adminService = {
      * 반려된 학원 리스트 조회
      * GET /api/admin/academy/rejected
      */
-    getRejectedAcademies: async (page = 0, size = 10, sort = 'createdAt,asc'): Promise<PageResponse<AcademyListResponse>> => {
+    async getRejectedAcademies(page = 0, size = 10, sort = 'createdAt,asc'): Promise<PageResponse<AcademyListResponse>> {
         const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/academy/rejected', {
             params: { page, size, sort }
         });
@@ -31,11 +31,22 @@ export const adminService = {
     },
 
     /**
+     * 전체 학원 리스트 조회
+     * GET /api/admin/academy
+     */
+    getAllAcademies: async (page = 0, size = 10, sort = 'createdAt,desc'): Promise<PageResponse<AcademyListResponse>> => {
+        const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/academy', {
+            params: { page, size, sort }
+        });
+        return response.data;
+    },
+
+    /**
      * 학원 상세 조회 (관리자용)
-     * GET /api/academy/{id}
+     * GET /api/admin/academy/{id}
      */
     getAcademyDetail: async (academyId: string | number): Promise<AcademyResponse> => {
-        const response = await axiosInstance.get<AcademyResponse>(`/api/academy/${academyId}`);
+        const response = await axiosInstance.get<AcademyResponse>(`/api/admin/academy/${academyId}`);
         return response.data;
     },
 

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,5 +1,4 @@
 import axiosInstance from '@/api/axiosInstance';
-import { AcademyInfo } from '@/types/dashboard';
 import { 
   AcademyRejectRequest, 
   PageResponse, 

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,0 +1,49 @@
+import axiosInstance from '@/api/axiosInstance';
+import { AcademyInfo } from '@/types/dashboard';
+import { 
+  AcademyRejectRequest, 
+  PageResponse, 
+  AcademyListResponse, 
+  AcademyResponse 
+} from '@/types/admin';
+
+export const adminService = {
+    /**
+     * 승인 대기 중인 학원 리스트 조회
+     * GET /api/admin/pending
+     */
+    getPendingAcademies: async (page = 0, size = 10, sort = 'createdAt,asc'): Promise<PageResponse<AcademyListResponse>> => {
+        const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/pending', {
+            params: { page, size, sort }
+        });
+        return response.data;
+    },
+
+    /**
+     * 학원 상세 조회 (관리자용)
+     * GET /api/academy/{id}
+     */
+    getAcademyDetail: async (academyId: string | number): Promise<AcademyResponse> => {
+        const response = await axiosInstance.get<AcademyResponse>(`/api/academy/${academyId}`);
+        return response.data;
+    },
+
+    /**
+     * 학원 승인 (APPROVE)
+     * POST /api/admin/academy/{id}/approve
+     */
+    approveAcademy: async (academyId: string | number): Promise<void> => {
+        await axiosInstance.post(`/api/admin/academy/${academyId}/approve`);
+    },
+
+    /**
+     * 학원 반려 (REJECT)
+     * POST /api/admin/academy/{id}/reject
+     */
+    rejectAcademy: async (academyId: string | number, reason: string): Promise<void> => {
+        const body: AcademyRejectRequest = { rejectionReason: reason };
+        // 디버깅용 로그
+        console.log(`[AdminService] Rejecting academy: ID=${academyId}, URL=/api/admin/academy/${academyId}/reject`, body);
+        await axiosInstance.post(`/api/admin/academy/${academyId}/reject`, body);
+    },
+};

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -10,10 +10,21 @@ import {
 export const adminService = {
     /**
      * 승인 대기 중인 학원 리스트 조회
-     * GET /api/admin/pending
+     * GET /api/admin/academy/pending
      */
     getPendingAcademies: async (page = 0, size = 10, sort = 'createdAt,asc'): Promise<PageResponse<AcademyListResponse>> => {
-        const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/pending', {
+        const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/academy/pending', {
+            params: { page, size, sort }
+        });
+        return response.data;
+    },
+
+    /**
+     * 반려된 학원 리스트 조회
+     * GET /api/admin/academy/rejected
+     */
+    getRejectedAcademies: async (page = 0, size = 10, sort = 'createdAt,asc'): Promise<PageResponse<AcademyListResponse>> => {
+        const response = await axiosInstance.get<PageResponse<AcademyListResponse>>('/api/admin/academy/rejected', {
             params: { page, size, sort }
         });
         return response.data;

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -58,5 +58,15 @@ export const dashboardService = {
             }
         );
         return response.data;
+    },
+
+    /**
+     * 학원 승인 재신청
+     * PUT /api/academy/{id}/resubmit
+     */
+    resubmitAcademy: async (academyId: string | number, data: FormData): Promise<void> => {
+        const url = `/api/academy/${academyId}/resubmit`;
+        console.log(`[DashboardService] Resubmitting to ${url} (PUT)`);
+        await axiosInstance.put(url, data);
     }
 };

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -7,15 +7,28 @@ export interface PageResponse<T> {
 }
 
 export interface AcademyListResponse {
-  academyId: number;
+  id: number;
+  academyId?: number; // 호환용
   name: string;
   approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
   rejectionReason?: string;
-  item?: any; // 추가적인 리스트 아이템 정보가 있을 경우
+  item?: any;
+}
+
+export interface AgeGroup {
+  id: number;
+  ageCode: string;
+}
+
+export interface Subject {
+  id: number;
+  mainSubjectCode: string;
+  detailSubject: string;
 }
 
 export interface AcademyResponse {
-  academyId: number;
+  id: number;
+  academyId?: number; // 호환용
   name: string;
   approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
   rejectionReason?: string;
@@ -43,9 +56,13 @@ export interface AcademyResponse {
   certificate?: string; // 사업자등록증 이미지 URL 등
   imageUrls?: string[];
   
-  // 분류
-  ages?: string[];
-  subjects?: string[];
+  // 분류 (JSON 구조에 맞게 수정)
+  ages?: AgeGroup[];
+  subjects?: Subject[];
+
+  // 등록자(원장님) 정보
+  userName?: string;
+  userPhoneNumber?: string;
 }
 
 export interface AcademyRejectRequest {

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,53 @@
+export interface PageResponse<T> {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number; // current page
+}
+
+export interface AcademyListResponse {
+  academyId: number;
+  name: string;
+  approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
+  rejectionReason?: string;
+  item?: any; // 추가적인 리스트 아이템 정보가 있을 경우
+}
+
+export interface AcademyResponse {
+  academyId: number;
+  name: string;
+  approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
+  rejectionReason?: string;
+  
+  // 주소
+  address?: string;
+  baseAddress?: string; // 도로명
+  detailAddress?: string; // 상세
+  
+  // 연락처
+  phoneNumber?: string;
+  
+  // 소개
+  briefInfo?: string;
+  detailInfo?: string;
+  costInfo?: string;
+  operatingHours?: string;
+  
+  // 링크
+  blogUrl?: string;
+  websiteUrl?: string;
+  instagramUrl?: string;
+  
+  // 인증서 및 이미지
+  certificate?: string; // 사업자등록증 이미지 URL 등
+  imageUrls?: string[];
+  
+  // 분류
+  ages?: string[];
+  subjects?: string[];
+}
+
+export interface AcademyRejectRequest {
+  rejectionReason: string;
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -9,7 +9,7 @@ export interface DashboardStatsData {
 export interface ReceiptSummary {
     className: string;
     classTime: string;
-    status: 'BEFORE_REQUEST' | 'ISSUED' | 'PAID';
+    status: 'BEFORE_REQUEST' | 'ISSUED' | 'PAID' | 'NO_STUDENTS';
     statusLabel: string;
     totalAmount: number;
 }
@@ -24,7 +24,15 @@ export interface ClassSummary {
 }
 
 export interface AcademyInfo {
-    academyId: number;
+    id: number; // API 실제 필드
+    academyId?: number; // 기존 코드 호환용
     name: string;
     approvalStatus: 'REJECTED' | 'PENDING' | 'APPROVED';
+    rejectionReason?: string;
+    phoneNumber?: string;
+    address?: string;
+    baseAddress?: string;
+    detailAddress?: string;
+    certificate?: string; // 추가: Nginx 저장 경로
+    businessRegistrationUrl?: string; // 기존 호환용
 }

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -3,6 +3,7 @@ export interface StudentDetail {
   studentName: string;
   amount: number;
   status: 'BEFORE_REQUEST' | 'ISSUED' | 'PAID';
+  isCardRegistered: boolean;
 }
 
 export interface ClassSummary {


### PR DESCRIPTION
관리자 통합 관리 시스템 구축 및 서비스 UX 고도화

### **1. 통합 학원 관리 시스템 (Admin Dashboard)**
*   **전방위 탭 시스템 도입**: '전체', '승인 대기 중', '반려됨' 학원을 명확히 분리하여 운영 목적에 따른 실시간 리스트 필터링이 가능합니다. (`/api/admin/academy` 시리즈 연동)
*   **실시간 지능형 검색**: 탭 구분 없이 학원명으로 즉시 필터링되는 검색 기능을 구현하여 데이터 접근 속도를 최적화했습니다.
*   **관리 도구 최적화 UI**: 
    *   화면 너비를 **1080px**로 최적화하여 정보 집중도를 높였습니다.
    *   학원명 컬럼을 축소하고 **거절 사유 컬럼을 대폭 확장**하여 반려 사유 확인의 편의성을 강화했습니다.
    *   대기 중(옐로우), 반려됨(레드), **승인됨(블루)**의 직관적인 상태 배지 시스템을 구축했습니다.

### **2. 심사 심층 데이터 시각화 (Detailed Review Modal)**
*   **신규 데이터 섹션 구축**:
    *   **등록자 정보**: 학원 정보와 별개로 원장님의 성함과 연락처(`userName`, `userPhoneNumber`)를 별도 섹션으로 제공합니다.
    *   **대상 및 과목 정보**: 백엔드 실제 객체 구조(`ages`, `subjects`)를 직접 바인딩하여 정확한 연령대와 상세 과목명을 렌더링합니다.
*   **이미지 라이트박스(Lightbox)**: 사업자등록증 확인 시 새 창 이동 없이 모달 내에서 즉시 확대가 가능하도록 구현하여 심사 동선을 최소화했습니다.
*   **워크플로우 일관성**: 브라우저 기본 알림(`confirm`)을 제거하고 서비스 전용 **승인 확인 모달**을 적용하여 브랜드 일관성을 확보했습니다.
*   **디테일 디자인**: 얇고 세련된 **커스텀 슬림 스크롤바**와 둥근 모서리 보정 CSS를 통해 고급스러운 관리 툴 감성을 제공합니다.

### **3. 학원 대시보드 및 재심사 프로세스**
*   **자동 반려 대응 로직**: 원장님이 대시보드 진입 시 반려 상태(`REJECTED`)인 경우, 즉시 수정 모달을 띄우고 기존 서류 미리보기를 제공하여 빠른 재신청을 유도합니다.
*   **주소 정보 정밀화**: 백엔드 스키마와 정합성을 맞추기 위해 `baseAddress`(도로명)와 `detailAddress`(상세)를 분리하여 데이터 정확도를 높였습니다.
*   **파일 전송 고도화**: `multipart/form-data` 기반의 재신청 API를 통해 이미지와 텍스트 데이터를 안정적으로 서버에 전달합니다.

### **4. 원생 관리 UX 개선 (Student Registration)**
*   **엑셀 드래그 앤 드롭(Drag & Drop)**: 기존 클릭 업로드 방식에 더해, 파일을 직접 끌어다 놓는 드래그 앤 드롭 기능을 추가하여 원생 일괄 등록의 편의성을 대폭 개선했습니다.
*   **시각적 피드백**: 파일 드래그 시 업로드 영역 하이라이트 효과를 통해 직관적인 대화형 UX를 구현했습니다.

### **5. 시스템 안정성 및 유연성 (Robustness)**
*   **ID Fallback 매핑**: 목록 API(`academyId`)와 상세 API(`id`) 간의 필드명 불일치 문제를 해결하기 위해 **Fallback 로직**을 적용, `undefined` 조회를 원천 차단했습니다.
*   **관리자 전용 엔드포인트**: 상세 조회를 관리자 전용 API(`/api/admin/academy/{id}`)로 전환하여 보안과 관리 효율을 동시에 확보했습니다.

<img width="729" height="873" alt="스크린샷 2026-01-27 142713" src="https://github.com/user-attachments/assets/d4431895-42a8-47fe-a535-92015aa36717" />
<img width="663" height="836" alt="스크린샷 2026-01-27 142721" src="https://github.com/user-attachments/assets/f65ad563-4c36-4c87-83a8-e924f203593c" />
<img width="264" height="117" alt="스크린샷 2026-01-27 142730" src="https://github.com/user-attachments/assets/b7806c6f-78cf-4dfb-9774-1b04ac03f24e" />

<img width="1919" height="491" alt="스크린샷 2026-01-27 152950" src="https://github.com/user-attachments/assets/97d2dbb7-88f0-403d-b06f-e379d969413f" />
<img width="1919" height="480" alt="스크린샷 2026-01-27 153000" src="https://github.com/user-attachments/assets/1b2f0d38-aec3-4e35-9de2-588f2958375d" />

Closes #42 